### PR TITLE
hack to handle pdf figures in notebook

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -96,9 +96,9 @@ RST_TEMPLATE = """
 {{ insert_empty_lines(outputdata) }}
 
 {{ outputdata.strip(\n) | indent }}
-{%- elif datatype in ['image/svg+xml', 'image/png', 'image/jpeg'] %}
+{%- elif datatype in ['image/svg+xml', 'image/png', 'image/jpeg', 'application/pdf'] %}
 
-    .. image:: {{ output.metadata.filenames[datatype] | posix_path }}
+    .. image:: {{ output.metadata.filenames[datatype].rsplit('.', 1)[0] + '.*' | posix_path }}
 {%- elif datatype in ['text/markdown'] %}
 
 {{ output.data['text/markdown'] | markdown2rst | indent }}


### PR DESCRIPTION
This may not be the correct way to handle it, but it was the easiest way to fix this bug:

In some of my notebooks, I use this code block, which causes issues:

```python
from IPython.display import set_matplotlib_formats
set_matplotlib_formats('png', 'pdf')
```

Specifically, it causes the notebook output to look like this:
```json
"outputs": [
    {
     "data": {
      "application/pdf": "JVBERi0xLjQKJazcIKu6CjEgMCBvYmoKPD<etc>==\n",
      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAV0AAADtCAYAAAAc<etc>=\n",
      "text/plain": [
       "<matplotlib.figure.Figure at 0x7f7c2c22f3d0>"
      ]
     },
     "metadata": {},
     "output_type": "display_data"
    }
   ],
```

When I run this with sphinx, I get the following in my built html file:
![image](https://cloud.githubusercontent.com/assets/1380168/12709549/1a08b390-c862-11e5-8d32-1dcd4214f20e.png)

This basically just changes the template so instead of having an extension on the written filename of the image, it leaves it with an asterix (i.e. my_image.* instead of my_image.png). This lets sphinx choose the appropriate image based on the backend ([sphinx docs link](http://www.sphinx-doc.org/en/stable/rest.html#images))

This assumes the extension is 3 characters, which I thought was probably a fairly good assumption (png, pdf, jpg, svg), but maybe there will be exceptions I haven't thought of.