### PR TITLE
Fix emtpy -> empty typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 build/
 dist/
 nbsphinx.egg-info/
+.ipynb_checkpoints/

--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -475,7 +475,7 @@ class NbInput(rst.Directive):
         text = '\n'.join(self.content.data)
         node = CodeNode.create(
             text, language=self.arguments[0] if self.arguments else 'none')
-        _set_emtpy_lines(node, self.options)
+        _set_empty_lines(node, self.options)
         node.attributes['latex_prompt'] = latex_prompt
         container += node
         return [container]
@@ -524,7 +524,7 @@ class NbOutput(rst.Directive):
         else:
             text = '\n'.join(self.content.data)
             node = CodeNode.create(text)
-            _set_emtpy_lines(node, self.options)
+            _set_empty_lines(node, self.options)
             node.attributes['latex_prompt'] = latex_prompt
             container += node
         return [container]
@@ -574,7 +574,7 @@ def _get_empty_lines(text):
     return before, after
 
 
-def _set_emtpy_lines(node, options):
+def _set_empty_lines(node, options):
     """Set "empty lines" attributes on a CodeNode.
 
     See http://stackoverflow.com/q/34050044/500098.
@@ -771,7 +771,7 @@ def depart_code_latex(self, node):
 
     * Remove the frame (by changing Verbatim -> OriginalVerbatim)
     * Add empty lines before and after the code
-    * Add prompt to the first line, emtpy space to the following lines
+    * Add prompt to the first line, empty space to the following lines
 
     """
     lines = self.body[-1].split('\n')


### PR DESCRIPTION
Hi, thanks for this project! We had been doing something similar, but not as robust, in our own project, so I'm very excited to switch to using `nbsphinx`. There are a few things that we need that aren't currently done in this project, so I have a series of PRs coming in. Since I notice that your repo history is linear (which we do in our project as well) I've ordered the PRs so that they can be rebased/merged easily.

This is the first PR; I noticed a typo in `nbsphinx.py` so this fixes the typo. It also adds `.ipynb_checkpoints` to `.gitignore` as these are likely to crop up when editing the notebooks in the `docs` folder.