### PR TITLE
Add nbsphinx_timeout option

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,11 +13,16 @@ extensions = [
 # Exclude build directory and Jupyter backup files:
 exclude_patterns = ['_build', '**.ipynb_checkpoints']
 
-# If True, the build process is continued even if an exception occurs:
-#nbsphinx_allow_errors = True
-
 # Default language for syntax highlighting (e.g. in Markdown cells)
 highlight_language = 'none'
+
+# -- These set defaults that can be overridden through notebook metadata --
+
+# See http://nbsphinx.readthedocs.org/en/latest/allow-errors.html
+# for more details.
+
+# If True, the build process is continued even if an exception occurs:
+#nbsphinx_allow_errors = True
 
 # -- The settings below this line are not specific to nbsphinx ------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,10 +19,13 @@ highlight_language = 'none'
 # -- These set defaults that can be overridden through notebook metadata --
 
 # See http://nbsphinx.readthedocs.org/en/latest/allow-errors.html
-# for more details.
+# and http://nbsphinx.readthedocs.org/en/latest/timeout.html for more details.
 
 # If True, the build process is continued even if an exception occurs:
 #nbsphinx_allow_errors = True
+
+# Controls when a cell will time out (defaults to 30; use -1 for no timeout):
+#nbsphinx_timeout = 60
 
 # -- The settings below this line are not specific to nbsphinx ------------
 

--- a/doc/index.ipynb
+++ b/doc/index.ipynb
@@ -26,6 +26,7 @@
     "* [Raw Cells](raw-cells.ipynb)\n",
     "* [A Pre-Executed Notebook](pre-executed.ipynb)\n",
     "* [Ignoring Errors](allow-errors.ipynb)\n",
+    "* [Long-Running Cells](timeout.ipynb)\n",
     "* [Hidden Cells](hidden-cells.ipynb)\n",
     "* [A Notebook in a Sub-Directory](subdir/another.ipynb)\n",
     "* [Using `toctree` In A Notebook](subdir/toctree.ipynb)\n",

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,6 +13,7 @@ generated from Jupyter notebooks.
     raw-cells.ipynb
     pre-executed.ipynb
     allow-errors.ipynb
+    timeout.ipynb
     hidden-cells.ipynb
     subdir/*
     rst.rst

--- a/doc/pre-executed.ipynb
+++ b/doc/pre-executed.ipynb
@@ -27,9 +27,11 @@
    "source": [
     "## Long-Running Cells\n",
     "\n",
-    "If you are doing some very time-consuming computations, it might not be feasible to re-execute the notebook every time you build your Sphinx documentation.\n",
+    "If you are doing some very time-consuming computations, you may go over the default timeout for a cell, which is 30 seconds. To include long-running cells, you have two choices:\n",
     "\n",
-    "So just do it once - when you happen have the time - and then just keep the output."
+    "1. Change the timeout for a cell either generally or on a per-notebook basis -- see [Long-Running Cells](timeout.ipynb).\n",
+    "\n",
+    "1. Execute the notebook beforehand and save the results, like it's done in this example notebook:"
    ]
   },
   {

--- a/doc/timeout.ipynb
+++ b/doc/timeout.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `nbsphinx` documentation: http://nbsphinx.readthedocs.org/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Long-Running Cells\n",
+    "\n",
+    "By default, `nbconvert` will give a cell 30 seconds to execute before it times out.\n",
+    "\n",
+    "If you would like to change the amount of time given for a cell, you have three options:\n",
+    "\n",
+    "1. Manually execute the notebook in question and save the results, see [the pre-executed example notebook](pre-executed.ipynb#Long-Running-Cells).\n",
+    "\n",
+    "2. Change the timeout length for all notebooks by setting this option in [conf.py](conf.py):\n",
+    "```\n",
+    "nbsphinx_timeout = 60  # Time in seconds; use -1 for no timeout\n",
+    "```\n",
+    "\n",
+    "3. Change the timeout length on a per-notebook basis by adding this to the notebook's JSON metadata:\n",
+    "```json\n",
+    "\"nbsphinx\": {\n",
+    "  \"timeout\": 60\n",
+    "}\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1+"
+  },
+  "nbsphinx": {
+   "timeout": 60
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -358,8 +358,8 @@ class Exporter(nbconvert.RSTExporter):
         # Execute notebook only if there are code cells and no outputs:
         if (any(c.source for c in nb.cells if c.cell_type == 'code') and
                 not any(c.outputs for c in nb.cells if 'outputs' in c)):
-            allow_errors = (self._allow_errors or
-                            nbsphinx_metadata.get('allow_errors', False))
+            allow_errors = nbsphinx_metadata.get(
+                'allow_errors', self._allow_errors)
             pp = nbconvert.preprocessors.ExecutePreprocessor(
                 allow_errors=allow_errors)
             nb, resources = pp.preprocess(nb, resources)


### PR DESCRIPTION
This is the second PR. In our project, we have several cells that take quite a while to compute, so we encountered a `TimeoutError` when generating our docs.

I tried modifying the timeout through a config files in `~/.jupyter/jupyter_nbconvert_config.py`, but that does not appear to be read when import a preprocessor directory, so I had to add an option through `nbsphinx`. Not sure if there's another way to handle this? In any case, this works for us.

I also added a new notebook to the docs describing how to use the option, similar to the `allow_errors` option.