### PR TITLE
Add option for changing default language

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,7 +13,7 @@ extensions = [
 # Exclude build directory and Jupyter backup files:
 exclude_patterns = ['_build', '**.ipynb_checkpoints']
 
-# Default language for syntax highlighting (e.g. in Markdown cells)
+# Default language for syntax highlighting in reST and Markdown cells
 highlight_language = 'none'
 
 # -- These set defaults that can be overridden through notebook metadata --
@@ -26,6 +26,9 @@ highlight_language = 'none'
 
 # Controls when a cell will time out (defaults to 30; use -1 for no timeout):
 #nbsphinx_timeout = 60
+
+# Default Pygments lexer for syntax highlighting in code cells
+#nbsphinx_codecell_lexer = 'ipython3'
 
 # -- The settings below this line are not specific to nbsphinx ------------
 


### PR DESCRIPTION
This is the third PR. Our project has been building IPython notebooks in docs for quite a while, so currently our notebooks are still in version 3 of the notebook format. Generally this is fine and they get converted successfully in the build process, but syntax highlighting doesn't work because there is no `language_info` metadata generated in the conversion process. Maybe this is an nbconvert bug, but in any case, this PR makes it possible to set a default language that will be used if no language is found in the notebook metadata.

The implementation of this is definitely more of a hack than the other PRs, so if you have any thoughts of other ways to do this, I'm happy to change it! We will update our notebooks to v4 eventually, but this strikes me as a useful thing in other weird cases anyhow.