### PR TITLE
Add notebook directive

### DIFF
--- a/doc/rst.rst
+++ b/doc/rst.rst
@@ -36,6 +36,26 @@ These links were created with:
     * "``../``" is not allowed, you have to specify the full path even if the
       current source file is in a subdirectory!
 
+Sphinx Directive for Including Notebooks
+----------------------------------------
+
+Notebooks can also be included directly in an RST file
+using the ``nbinclude`` directive.
+Below, we include :ref:`subdir2/included.ipynb`.
+
+.. nbinclude:: subdir2/included.ipynb
+
+The notebook was included with:
+
+.. code-block:: rst
+
+    .. nbinclude:: subdir2/included.ipynb
+
+.. note::
+
+    * "``../``" is allowed here. In fact, you can include notebooks that are
+      outside of the documentation directory!
+
 Sphinx Directives for Jupyter Notebook Cells
 --------------------------------------------
 

--- a/doc/rst.rst
+++ b/doc/rst.rst
@@ -36,26 +36,6 @@ These links were created with:
     * "``../``" is not allowed, you have to specify the full path even if the
       current source file is in a subdirectory!
 
-Sphinx Directive for Including Notebooks
-----------------------------------------
-
-Notebooks can also be included directly in an RST file
-using the ``nbinclude`` directive.
-Below, we include :ref:`subdir2/included.ipynb`.
-
-.. nbinclude:: subdir2/included.ipynb
-
-The notebook was included with:
-
-.. code-block:: rst
-
-    .. nbinclude:: subdir2/included.ipynb
-
-.. note::
-
-    * "``../``" is allowed here. In fact, you can include notebooks that are
-      outside of the documentation directory!
-
 Sphinx Directives for Jupyter Notebook Cells
 --------------------------------------------
 
@@ -93,3 +73,23 @@ This was created with
         :execution-count: 42
 
         42
+
+Sphinx Directive for Including Notebooks
+----------------------------------------
+
+Notebooks can be included directly in an RST file
+using the ``nbinclude`` directive.
+Below, we include :ref:`subdir2/included.ipynb`.
+
+.. nbinclude:: subdir2/included.ipynb
+
+The notebook was included with:
+
+.. code-block:: rst
+
+    .. nbinclude:: subdir2/included.ipynb
+
+.. note::
+
+    * "``../``" is allowed here. In fact, you can include notebooks that are
+      outside of the documentation directory!

--- a/doc/subdir2/included.ipynb
+++ b/doc/subdir2/included.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `nbsphinx` documentation: http://nbsphinx.readthedocs.org/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### An Included Notebook\n",
+    "\n",
+    "This notebook is included with the `nbinclude` directive.\n",
+    "\n",
+    "The cell below is stored unexecuted, but will be executed when included, just like notebooks included in a `:toctree:`. Notebooks with at least one executed cell will not be executed when included."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "6 * 7"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1+"
+  },
+  "nbsphinx": {
+   "orphan": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/doc/subdir2/included.ipynb
+++ b/doc/subdir2/included.ipynb
@@ -17,7 +17,11 @@
     "\n",
     "This notebook is included with the `nbinclude` directive.\n",
     "\n",
-    "The cell below is stored unexecuted, but will be executed when included, just like notebooks included in a `:toctree:`. Notebooks with at least one executed cell will not be executed when included."
+    "The cell below is stored unexecuted,\n",
+    "but will be executed when included,\n",
+    "just like notebooks included in a ``toctree``.\n",
+    "Notebooks with at least one executed cell will not be executed when included\n",
+    "(see [A Pre-Executed Notebook](../pre-executed.ipynb) for more details)."
    ]
   },
   {
@@ -29,6 +33,37 @@
    "outputs": [],
    "source": [
     "6 * 7"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Local images work like notebooks in `toctree`s:\n",
+    "![Jupyter notebook icon](../images/notebook_icon.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import Image\n",
+    "Image(filename='../images/notebook_icon.png')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A link to a notebook in the parent directory: [link](../markdown-cells.ipynb).\n",
+    "\n",
+    "A link to a specific section in that notebook: [link](../markdown-cells.ipynb#Links-to-Other-Notebooks).\n",
+    "\n",
+    "A link to a local file: [link](../images/notebook_icon.png)."
    ]
   }
  ],

--- a/doc/subdir2/included.ipynb
+++ b/doc/subdir2/included.ipynb
@@ -49,9 +49,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.1+"
-  },
-  "nbsphinx": {
-   "orphan": true
   }
  },
  "nbformat": 4,

--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -575,6 +575,13 @@ class NbInclude(rst.Directive):
             raise self.severe(
                 u'Problems with "nbinclude" directive:\n%s.' % error)
 
+        # Add the docname to the `files_to_rebuild` dictionary,
+        # which maps from files to files that include that file in a toctree.
+        # This suppresses the warning that is usually raised when a file
+        # is not in any toctree.
+        name, _ = os.path.splitext(os.path.relpath(path, settings.env.srcdir))
+        settings.env.files_to_rebuild.setdefault(name, set())
+
         # Use the NotebookParser to get doctree nodes
         nbparser = NotebookParser()
         node = docutils.utils.new_document(path, settings)

--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -401,11 +401,12 @@ class NotebookParser(rst.Parser):
         return rst.Parser.get_transforms(self) + [ProcessLocalLinks,
                                                   CreateSectionLabels]
 
-    def parse(self, inputstring, document):
+    def parse(self, inputstring, document, srcdir=None):
         """Parse `inputstring`, write results to `document`."""
         nb = nbformat.reads(inputstring, as_version=_ipynbversion)
         env = document.settings.env
-        srcdir = os.path.dirname(env.doc2path(env.docname))
+        if srcdir is None:
+            srcdir = os.path.dirname(env.doc2path(env.docname))
         auxdir = os.path.join(env.doctreedir, 'nbsphinx')
         sphinx.util.ensuredir(auxdir)
 
@@ -585,7 +586,7 @@ class NbInclude(rst.Directive):
         # Use the NotebookParser to get doctree nodes
         nbparser = NotebookParser()
         node = docutils.utils.new_document(path, settings)
-        nbparser.parse(rawtext, node)
+        nbparser.parse(rawtext, node, srcdir=os.path.dirname(path))
         if isinstance(node.children[0], docutils.nodes.field_list):
             return node.children[1:]
         return node.children


### PR DESCRIPTION
This is the fourth and final PR. In our project, the notebooks that we include in the documentation are examples of using our library. We have the examples in the top-level of the repository so that people visiting the repo see them front-and-center and can look through them. Unfortunately, since Sphinx doesn't allow `toctree` entries that are not in the root folder of the documentation, we can't include these examples simply by adding them to `toctree` entries.

Similar to how files like `README.rst` can be added with the `include` directive, this PR adds a `notebook` directive that you can point at a notebook outside of the `doc` directory. It also allows you to have one `.rst` file that includes multiple notebooks, which I can imagine being useful.

The actual implementation of the directive is basically how `docutils`'s `include` directive works, but then uses the `NotebookParser` to insert blocks into the document. 4fd8fe813399d1 shows how this works by eliminating the duplication between `doc/index.rst` and `doc/index.ipynb`. It seems like bi-directional communication works perfectly; now reST files can have notebooks in them, while notebooks can have raw reST cells in them! It's very nice, and definitely not something we were able to do with our previous implementation.

One issue with the last commit is that when I build the Sphinx docs, I don't get links in the left sidebar, so I may be missing something critical in this PR. Similarly, the `subdir/toctree.ipynb` notebook doesn't show up, even though it is included in `index.ipynb`. Any idea why that might be?
