### PR TITLE
Add pandoc filter to convert raw LaTeX to "math" directives

### DIFF
--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -38,9 +38,9 @@
     "\n",
     "Equations can be formatted really nicely, either inline, like $\\text{e}^{i\\pi} = -1$, or on a separate line, like\n",
     "\n",
-    "$$\n",
+    "\\begin{equation}\n",
     "\\int_{-\\infty}^\\infty f(x) \\delta(x - x_0) dx = f(x_0)\n",
-    "$$\n",
+    "\\end{equation}\n",
     "\n",
     "*Note:* Avoid leading and trailing spaces around math expressions, otherwise errors like the following will occur when Sphinx is running:\n",
     "\n",
@@ -175,7 +175,6 @@
   }
  ],
  "metadata": {
-  "celltoolbar": "Raw Cell Format",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -195,5 +194,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
This should be about the same behavior as the Jupyter Notebook has, as well as `nbconvert` with `html` and `latex` outputs.