### PR TITLE
Fix inclusion of CSS

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -513,6 +513,7 @@ class NbInput(rst.Directive):
         _set_empty_lines(node, self.options)
         node.attributes['latex_prompt'] = latex_prompt
         container += node
+        self.state.document['nbsphinx_include_css'] = True
         return [container]
 
 
@@ -562,6 +563,7 @@ class NbOutput(rst.Directive):
             _set_empty_lines(node, self.options)
             node.attributes['latex_prompt'] = latex_prompt
             container += node
+        self.state.document['nbsphinx_include_css'] = True
         return [container]
 
 
@@ -807,12 +809,10 @@ def builder_inited(app):
 
 
 def html_page_context(app, pagename, templatename, context, doctree):
-    """Add CSS string to HTML pages created from notebooks."""
-    body = context.get('body')
-    # page_source_suffix is available since Sphinx version 1.3.6
-    if body and context.get('page_source_suffix') in ('.ipynb', None):
+    """Add CSS string to HTML pages that contain code cells."""
+    if doctree and doctree.get('nbsphinx_include_css'):
         style = '\n<style>' + CSS_STRING + '</style>\n'
-        context['body'] = style + body
+        context['body'] = style + context['body']
 
 
 def html_collect_pages(app):


### PR DESCRIPTION
This hopefully fixes the bug described in https://github.com/spatialaudio/nbsphinx/issues/1#issuecomment-209125641.

I'm not sure if it's allowed to add new fields to the `document` and I don't know if `True` is a meaningful value for an attribute of `document` ...