### PR TITLE
add scrollbar to overly long output lines

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -236,6 +236,14 @@ div.nboutput div[class^=highlight] pre {
     box-shadow: none;
 }
 
+/* avoid overly long output lines 
+   Whitespace is preserved by the browser. 
+   Text will wrap when necessary, and on line breaks. 
+*/
+div.nboutput div[class^=highlight] pre {
+    white-space: pre-wrap;
+}
+
 /* avoid gaps between output lines */
 div.nboutput div[class^=highlight] pre {
     line-height: normal;

--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -236,14 +236,6 @@ div.nboutput div[class^=highlight] pre {
     box-shadow: none;
 }
 
-/* avoid overly long output lines 
-   Whitespace is preserved by the browser. 
-   Text will wrap when necessary, and on line breaks. 
-*/
-div.nboutput div[class^=highlight] pre {
-    white-space: pre-wrap;
-}
-
 /* avoid gaps between output lines */
 div.nboutput div[class^=highlight] pre {
     line-height: normal;
@@ -296,6 +288,7 @@ div.nboutput > :nth-child(2)[class^=highlight] {
     padding: 0.4em;
     -webkit-flex: 1;
     flex: 1;
+    overflow: auto;
 }
 
 /* input area */


### PR DESCRIPTION
This uses the CSS `white-space` property (http://www.w3schools.com/cssref/pr_text_white-space.asp).

Set to `pre-wrap` it has the following outcome:

- Whitespace is preserved by the browser. 
- Text will wrap when necessary, and on line breaks 

This works for my use-cases. I did not encounter any problems so far. 

Closes #40. 