### PR TITLE
Add :nowrap: option to math in output cells

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -141,8 +141,9 @@ RST_TEMPLATE = """
 {%- elif datatype in ['text/latex'] %}
 
     .. math::
+        :nowrap:
 
-{{ output.data['text/latex'] | strip_dollars | indent | indent }}
+{{ output.data['text/latex'] | indent | indent }}
 {%- elif datatype == 'text/html' %}
 
     .. raw:: html


### PR DESCRIPTION
This exposes a bug in Sphinx: https://github.com/sphinx-doc/sphinx/pull/2473

This PR should be merged after the bug has been resolved in Sphinx and a new Sphinx version has been released.

See also #43.
