### PR TITLE
ENH: Encapsulate Markdown Cell in Sphinx directive

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,6 +24,9 @@ highlight_language = 'none'
 # If True, the build process is continued even if an exception occurs:
 #nbsphinx_allow_errors = True
 
+# If True, this enables wrapping of markdown cells in sphinx-directives:
+#nbsphinx_allow_directives = True
+
 # Controls when a cell will time out (defaults to 30; use -1 for no timeout):
 #nbsphinx_timeout = 60
 

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -219,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.5.1+"
   }
  },
  "nbformat": 4,

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -177,17 +177,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Encapsulate Cell in Sphinx Directive\n",
-    "\n",
-    "To facilitate the use of Sphinx Directives, like admonitions (eg. ``.. warning::``), with processed markdown inside a specific metadata switch is added to the cells metadata:\n",
-    "\n",
-    "```\n",
-    "{\n",
-    "  \"nbsphinx-directive\": \"true\"\n",
-    "}\n",
-    "```\n",
-    "\n",
-    "The first line of the cell must contain the admonition type. It also has to be underlined to give the correct notion within the notebook. Below the output of such a cell is shown"
+    "## Encapsulate Cell in Sphinx Directive"
    ]
   },
   {
@@ -196,9 +186,25 @@
     "nbsphinx-directive": "true"
    },
    "source": [
-    "Warning\n",
-    "-------\n",
-    "Also normal markdown like math $\\text{e}^{i\\pi} = -1$, [links to somewhere](#Links-to-Other-Notebooks) or *emphasis*, **boldface** and `preformatted text` can be used within this cell."
+    "Important\n",
+    "---------\n",
+    "To facilitate the use of Sphinx Directives, like admonitions (eg. ``.. important:: ``), with processed markdown inside a specific metadata switch is added to the cells metadata:\n",
+    "\n",
+    "```python3\n",
+    "{\n",
+    "  \"nbsphinx-directive\": \"true\"\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "The first line of the cell must contain the admonition type. It also has to be underlined to give the correct notion within the notebook.\n",
+    "\n",
+    "Also the above mentioned markdown like:\n",
+    "\n",
+    "- Equations: $\\text{e}^{i\\pi} = -1$, \n",
+    "- Links: [link to somewhere](#Links-to-Other-Notebooks) or \n",
+    "- *emphasis*, **boldface** and `preformatted text` \n",
+    "\n",
+    "can be used within this cell. "
    ]
   }
  ],
@@ -219,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1+"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -209,7 +209,6 @@
   }
  ],
  "metadata": {
-  "celltoolbar": "Edit Metadata",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -196,7 +196,7 @@
     "}\n",
     "```\n",
     "\n",
-    "The first line of the cell must contain the admonition type. It also has to be underlined to give the correct notion within the notebook.\n",
+    "The first line of the cell must contain the admonition type. It also has to be underlined with `-` to be processed correctly and to give similar look within the notebook.\n",
     "\n",
     "Also the above mentioned markdown like:\n",
     "\n",

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -172,9 +172,38 @@
     "The linked files are automatically copied to the HTML output directory.\n",
     "For LaTeX output, no link is created."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Encapsulate Cell in Sphinx Directive\n",
+    "\n",
+    "To facilitate the use of Sphinx Directives, like admonitions (eg. ``.. warning::``), with processed markdown inside a specific metadata switch is added to the cells metadata:\n",
+    "\n",
+    "```\n",
+    "{\n",
+    "  \"nbsphinx-directive\": \"true\"\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "The first line of the cell must contain the admonition type. It also has to be underlined to give the correct notion within the notebook. Below the output of such a cell is shown"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx-directive": "true"
+   },
+   "source": [
+    "Warning\n",
+    "-------\n",
+    "Also normal markdown like math $\\text{e}^{i\\pi} = -1$, [links to somewhere](#Links-to-Other-Notebooks) or *emphasis*, **boldface** and `preformatted text` can be used within this cell."
+   ]
   }
  ],
  "metadata": {
+  "celltoolbar": "Edit Metadata",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -190,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1+"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -225,7 +225,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.5.1+"
   }
  },
  "nbformat": 4,

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -183,18 +183,12 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "nbsphinx-directive": "true"
+    "nbsphinx-directive": true
    },
    "source": [
     "Important\n",
     "---------\n",
-    "To facilitate the use of Sphinx Directives, like admonitions (eg. ``.. important:: ``), with processed markdown inside a specific metadata switch is added to the cells metadata:\n",
-    "\n",
-    "```python3\n",
-    "{\n",
-    "  \"nbsphinx-directive\": \"true\"\n",
-    "}\n",
-    "```\n",
+    "This facilitates the use of Sphinx Directives, like admonitions (eg. ``.. important:: ``), with processed markdown inside. \n",
     "\n",
     "The first line of the cell must contain the admonition type. It also has to be underlined with `-` to be processed correctly and to give similar look within the notebook.\n",
     "\n",
@@ -205,6 +199,31 @@
     "- *emphasis*, **boldface** and `preformatted text` \n",
     "\n",
     "can be used within this cell. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note\n",
+    "----\n",
+    "To use this behaviour there exist three possibilities:\n",
+    "\n",
+    "- add this metadata switch to the cells metadata to enable for the single cell\n",
+    "    ```python3\n",
+    "    {\n",
+    "      \"nbsphinx-directive\": true\n",
+    "    }\n",
+    "    ```\n",
+    "- add this metadata switch to the notebooks metadata to enable notebook wide:\n",
+    "    ```python3\n",
+    "    {\n",
+    "      \"nbsphinx\": {\n",
+    "        \"allow_directives\": true\n",
+    "       },\n",
+    "    }\n",
+    "    ```\n",
+    "- add `nbsphinx_allow_directives = True` in `conf.py` to enable doc-wide"
    ]
   }
  ],
@@ -225,6 +244,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.1+"
+  },
+  "nbsphinx": {
+   "allow_directives": true
   }
  },
  "nbformat": 4,

--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -684,8 +684,8 @@ def _wrap_cell(cell):
         text = text[0]
 
     text = nbconvert.filters.markdown2rst(text)
-    text = "".join([".. ", admon.lower(), "::\n\n\t",
-                    text.replace("\n", ' '), "\n"])
+    text = "".join([".. ", admon.lower(), ":: \n\n   ",
+                    text.replace("\n", '\n   '), "\n"])
 
     return text
 

--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -406,8 +406,10 @@ class Exporter(nbconvert.RSTExporter):
             nb, resources = pp.preprocess(nb, resources)
 
         # check allow directive
-        allow_directives = nbsphinx_metadata.get('allow_directives',
-                                                 self._allow_directives)
+        if self._allow_directives:
+            allow_directives = self._allow_directives
+        else:
+            allow_directives = nbsphinx_metadata.get('allow_directives', False)
         nbsphinx_metadata['allow_directives'] = allow_directives
         nb.metadata['nbsphinx'] = nbsphinx_metadata
 

--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -676,16 +676,14 @@ def _wrap_cell(cell):
     """Wrap cell content from Markdown cell in sphinx directive."""
     text = cell.source.split('\n', 2)
 
-    if len(text) > 2:
-        admon = text[0]
-        text = text[2]
+    # wrap only if at least 3 lines exist
+    # and if first line corresponds to second line
+    if (len(text) > 2) and (text[1] == ('-' * len(text[0]))):
+        text = "".join([".. ", text[0].lower(), ":: \n\n   ",
+                        nbconvert.filters.markdown2rst(text[2])
+                       .replace("\n", '\n   '), "\n"])
     else:
-        admon = 'note'
-        text = text[0]
-
-    text = nbconvert.filters.markdown2rst(text)
-    text = "".join([".. ", admon.lower(), ":: \n\n   ",
-                    text.replace("\n", '\n   '), "\n"])
+        text = nbconvert.filters.markdown2rst(cell.source)
 
     return text
 


### PR DESCRIPTION
This is a first proof of concept to encapsulate markdown cells in sphinx-directives. I use this to add admonitions to the rendered doc and in the same time have a quite similar look within the notebook.

My knowledge of templates and doc stuff is quite mediocre, so please be kind. I'm also not sure if this is the right place, where I added the "plugin". Also the code might need a little shaping.

I added an example to the `markdown-cells.ipynb` notebook for showing one use case.

Hoping for suggestions and a fruitful discussion in #46 . 