### PR TITLE
Add dependency on nbconvert "execute" extra requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     install_requires=[
         'docutils',
         'jinja2',
-        'nbconvert',
+        'nbconvert[execute]',
         'nbformat',
         'sphinx',
     ],


### PR DESCRIPTION
This in turn depends on `jupyter-client`.