### PR TITLE
TST: adds basic testing framework

### DIFF
--- a/tests/Basic.ipynb
+++ b/tests/Basic.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2\n"
+     ]
+    }
+   ],
+   "source": [
+    "x = 1\n",
+    "y = 2\n",
+    "print(x*y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Markdown\n",
+    "## Headers\n",
+    "*italic* **bold**\n",
+    "\n",
+    "* A list item\n",
+    "* Another list item\n",
+    "\n",
+    "1. A numbered list\n",
+    "2. A numbered list item\n",
+    "\n",
+    "$$x^2 - 1 = 0 \\implies x = \\pm j$$\n",
+    "\n",
+    "Some inline math $x^2 - 1 = 0 \\implies x = \\pm j$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXkAAAEACAYAAABWLgY0AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAG6VJREFUeJzt3Xt4VdWd//H3FwQsPx2sxVvpSKtAEQdURi5WlHipBK2C\nWOViYcQbWrHeOlVLLYzTGevUeRiFUYaLUBQER66KCqgcwXJLEUErMYCOhqBSFRCw3ML398eKkKaE\nHJJzzj5nn8/refKYk2z2+T7b5MPiu9da29wdERGJp3pRFyAiIumjkBcRiTGFvIhIjCnkRURiTCEv\nIhJjCnkRkRirMeTNbJyZfWpmqw9xzGNmttbM3jKzM1NbooiI1FYyI/nxQLfqvmlm3YFT3b0lMAgY\nlaLaRESkjmoMeXd/A9h8iEN6ABMrjl0GNDGzE1JTnoiI1EUqevLNgNJKr8sqviYiIhHTjVcRkRg7\nIgXnKAP+vtLr71R87W+YmTbKERGpBXe32vy5ZEfyVvFxMLOBAQBm1hnY4u6fVncid9eHO0OHDo28\nhmz50LXQtcjna/Hpp87jjztduzrHHOP07+88/7yzc+eBY+qixpG8mU0GCoBvmdlHwFCgYchrH+3u\nL5rZpWa2DtgBDKxTRSIiMbd5M0yfDlOnwvLlcNllcPfd0K0bNGqU2veqMeTdvV8SxwxOTTkiIvG0\nbRvMng1TpsDChfDDH8LNN8PMmdC4cfreNxU9eamFgoKCqEvIGroWB+haHBCHa/HVVzBnThixz58P\n558PffrA5Mlw9NGZqcHq2u85rDcz80y+n4hIpu3aBXPnhmCfMwc6dgzBfuWV8M1v1u6cZobX8sar\nQl5EpI727IHXXgvBPnMmtG0bgv2qq+D44+t+foW8iEiGlZfDokUh2KdNg1NOCcF+9dXQLMXLQesS\n8urJi4gkyR2WLQs3T599Fk48EXr3Dl/73veiru7gFPIiIjUoLoZJk8IN0wYNoG9fWLAAvv/9qCur\nmUJeROQgysrCiH3yZPjkk9CK+d//hbPOAqtV4yQa6smLiFTYsiX01ydNgrfeCjNirr0WunaF+vWj\nq0s3XkVEamnnzjDVcdIkePVVuPjiEOyXXgpHHhl1dYFCXkTkMJSXQyIRgn3mzNCCufZa6NULjjkm\n6ur+lkJeRKQG7vDmmyHYp0yBk04Kwd67d+qnPKaaplCKiFRj/foDM2P27AnB/tpr0Lp11JVlhkJe\nRGJn8+Ywj33iRFi3Dq65BiZMgE6dcmtmTCqoXSMisbBnD7z0Ejz1FMybF7btHTAg/LdBg6irqxv1\n5EUkL7nDihVhxD5lSlicNGBA2FogG2+g1pZ68iKSV0pL4emnQ7jv3h2CfckSOPXUqCvLPgp5EckJ\n27aFpylNnBgWKl19NYwdCz/4Qf712Q+H2jUikrXKy8MCpYkT4YUXwkM3BgyAH/0oexYqZYJ68iIS\nK++8E4J90iT49rdDsPfpA8cdF3Vl0VBPXkRy3ubN8MwzMH48fPwx9O8fHpnXpk3UleU2jeRFJDLl\n5fDKKyHYX345THccODA85DrKDcGyjdo1IpJT1q4Ni5MmToQTTgjB3rcvHHts1JVlJ7VrRCTrbdsW\n9mMfPx5KSsL2Ai++GJ6HKumjkbyIpI17eA7q+PEwY0bYl33gwLCNb8OGUVeXO9SuEZGsUloKv/99\naMk0ahSC/Sc/Cc9ElcOndo2IRG7XrjBaf/LJsNXANdeEnR87dNBipSgp5EWkTt59F8aMCdsMnHEG\nXH89zJoF3/hG1JUJKORFpBZ27Ahb+Y4dCx98ENoxS5dq75hspJ68iCRtxYowan/2WTj3XLjppnAT\n9QgNF9NKPXkRSZstW0JvfezYsCr1hhvg7bez/5F5EmgkLyJ/wx3+8Icwap81K6xEvfFGuOgiqFcv\n6uryj6ZQikhK/PnPYRXq2LHh9U03hT1k8nVjsGyhdo2I1Jo7vP46jBoV9o/p2VP7tMeJRvIieeqL\nL8KofdSocOP0llvCgqU4PTYvLjSSF5GkuMOyZSHYZ82Cyy4Lo/Zzz9WoPa40khfJA9u2hQdwjBoF\n27eHUft110HTplFXJsmoy0g+qfvkZlZoZsVmVmJm9x7k+39nZrPN7C0ze9vMrqtNMSKSWqtWwa23\nQvPmYd/2Rx4JO0D+/OcK+HxRY7vGzOoBI4GLgI1AkZnNcvfiSofdBvzJ3a8ws6bAe2b2tLvvTUvV\nIlKtv/wlLFYaNQrKysIMmXfeCY/Rk/yTTE++I7DW3T8EMLMpQA+gcsg7cHTF50cDnyvgRTKrpASe\neAKeego6dYJf/hK6d9dq1HyXzP/+ZkBppdcbCMFf2UhgtpltBI4CeqemPBE5lPJyeOklGDkSVq4M\nq1H/+Ef47nejrkyyRar+ju8GrHT3C83sVGC+mbVz9+1VDxw2bNj+zwsKCigoKEhRCSL544svwpa+\njz8eFioNHgwzZ8KRR0ZdmaRCIpEgkUik5Fw1zq4xs87AMHcvrHh9H+Du/nClY14AHnL3P1S8fhW4\n193/WOVcml0jUgcrV4ZR+/TpcMUVcNtt0LHqv6sldtI9T74IaGFmzYGPgT5A3yrHfAhcDPzBzE4A\nWgHv16YgEflru3fDtGkh3EtLw2yZkhJtNSDJqTHk3b3czAYD8whTLse5+xozGxS+7aOB3wATzGx1\nxR/7hbt/kbaqRfJAWRmMHh0+2rQJ0x4vv1w3UuXwaDGUSBb5+sHXI0fC/PnQr19oybRpE3VlEiVt\nayCS43buDHu2P/po+Hzw4LDNb5MmUVcmuU4hLxKhTz4Jc9tHjYL27eHhh+GSS7Rnu6SOfpREIvDm\nm/BP/wSnnRb2cH/99TDfvbBQAS+ppR8nkQwpL4cZM6BrV+jRI/TZ168Pc91bt466OokrtWtE0mzr\n1rBw6bHH4MQT4c47oVcvaNAg6sokHyjkRdJk3ToYMSLsJdOtGzzzDHTuHHVVkm/UrhFJIXdYuDC0\nY845Bxo3htWrFfASHY3kRVJg796w1cAjj8CWLXD33SHYGzeOujLJdwp5kTrYvh3Gj4fhw8N+7UOG\nhFWpmiEj2UIhL1ILn3wS+u2jR4fZMpMmhfaMSLbReEPkMKxZAzfeGOa3b9kCS5bAc88p4CV7aSQv\nUoOvb6Y+8ggUFYW9ZNau1TNSJTco5EWqUV4ebqb+7ndhrvs994Rnp37jG1FXJpI8hbxIFbt2wcSJ\n8B//EfZs181UyWUKeZEK27fD//xPmCnTti2MGwfnnQdWqw1eRbKDQl7y3uefhy0HHn8cLrwQnn8e\nzjor6qpEUkP/AJW8VVoKd90FLVvCxo2weDFMnaqAl3hRyEveee89uP56OOOM0Gd/++3wgI6WLaOu\nTCT11K6RvLFiBTz0UJgO+fU0yG99K+qqRNJLI3mJvSVLoHv3sGnYuefC++/D0KEKeMkPGslLbC1a\nBA8+GEbs998PM2dCo0ZRVyWSWQp5iRV3SCRCuH/0Efzyl9C/PzRsGHVlItFQyEssuMP8+SHcN22C\nX/0K+vWDI/QTLnlOvwKS09zDA7AffDBsPfDAA9C7N9SvH3VlItlBIS85yT0sWnrwwbANwQMPwFVX\nKdxFqlLIS05xhzlz4Ne/hn37wn979tS+MiLVUchLTvi65/7rX8OOHWEE37On9pURqYlCXrJeIhHa\nMZ99BsOGwdVXa+QukiyFvGStxYtDuH/4YVi81K+feu4ih0vjIck6RUVhhWq/fuFjzZow110BL3L4\nFPKSNVatClsPXHklXHEFlJTADTdAgwZRVyaSuxTyErn168OIvbAw7Oe+bh3ceqtWqYqkgkJeIvPJ\nJ2E3yE6d4LTTwh4zd9wBRx4ZdWUi8aGQl4zbujVsO3D66SHQi4vDDdajjoq6MpH4UchLxuzcCf/5\nnweexLRyZXjdtGnUlYnEV1Ihb2aFZlZsZiVmdm81xxSY2Uoze8fMFqS2TMlle/fCk09Cq1bwxhuw\nYEF4ffLJUVcmEn/m7oc+wKweUAJcBGwEioA+7l5c6ZgmwGLgEncvM7Om7v7ZQc7lNb2fxId72MN9\nyBA47jj47W/hnHOirkok95gZ7l6r9d3JLIbqCKx19w8r3mwK0AMornRMP2Cau5cBHCzgJb8sWwb3\n3ANffhlaMoWF2oJAJArJtGuaAaWVXm+o+FplrYBjzWyBmRWZWf9UFSi55YMPoG9f6NUrPCx75cqw\nsEkBLxKNVN14PQJoD3QHCoEHzKxFis4tOWDLFvjFL+Dss8N0yJKSEPJapSoSrWTaNWVA5Vtk36n4\nWmUbgM/cfSew08wWAmcA66qebNiwYfs/LygooKCg4PAqlqyyezeMGgX/9m9hleo778BJJ0VdlUhu\nSyQSJBKJlJwrmRuv9YH3CDdePwaWA33dfU2lY1oDIwij+EbAMqC3u79b5Vy68RoTX99UvfdeOOUU\n+N3voG3bqKsSiae03nh193IzGwzMI7R3xrn7GjMbFL7to9292MzmAquBcmB01YCX+HjzTbjzztCi\nGTECunWLuiIRqU6NI/mUvplG8jlt06YwHfLrx+7dcIN67iKZUJeRvFa8So327IHhw8M2BEcdFbYh\nuPlmBbxILtBDQ+SQXn4Z7roLmjeHhQvDzBkRyR0KeTmotWvh7rvDqH34cLjsMs11F8lFatfIX/ny\nyzDf/Zxz4LzzwpTIH/1IAS+SqxTyAoQpkZMmQevW8Oc/w9tvh7Bv1CjqykSkLtSuEd59Nzy8Y+tW\nmD4dOneOuiIRSRWN5PPYjh1w333QtStcdVV4gLYCXiReFPJ5yB1mzIA2baCsLLRmBg/WlEiROFK7\nJs+sXw+33w7/93/w+9+Dtg4SiTeN5PPErl1hlWqnTiHY33pLAS+SDzSSzwNvvBFWqLZqFfad0WP3\nRPKHQj7Gtm4NN1affx4eeyw8yENE8ovaNTE1Y0bYa8Y9LGhSwIvkJ43kY6asLMyUKS6GZ54Jq1ZF\nJH9pJB8T+/bBE0/AmWdCu3bhxqoCXkQ0ko+BkpKwt3t5OSQSoU0jIgIayee08vKwQ+QPfgBXXx1m\n0SjgRaQyjeRzVEkJXH891KsHy5bBqadGXZGIZCON5HNM5dH7NdeE9owCXkSqo5F8Dlm7FgYODHu7\nL10KLVpEXZGIZDuN5HPAvn3w6KPhQR4//jG8/roCXkSSo5F8ltuwAa67LmwLvGQJtGwZdUUikks0\nks9izz4L7duH/d4XLVLAi8jh00g+C23dGrYDXroUXngBOnaMuiIRyVUayWeZRYvCqtXGjWHlSgW8\niNSNRvJZYvduGDoUJkyA0aPh8sujrkhE4kAhnwXWrYM+feCkk8KeMyecEHVFIhIXatdE7JlnwtTI\n666D2bMV8CKSWhrJR+Srr+BnP4OFC2HePDjrrKgrEpE40kg+An/6E3ToADt3wooVCngRSR+FfAa5\nw5gx4QHaP/85PPUUHH101FWJSJypXZMhO3bALbeEG6sLF8Jpp0VdkYjkA43kM2DtWujc+cC2wAp4\nEckUhXyazZwJ554Lt90W5sA3bhx1RSKST9SuSZO9e+FXvwpTJLU1gYhERSGfBps2hcVN9euH2TNN\nm0ZdkYjkq6TaNWZWaGbFZlZiZvce4rgOZrbHzHqlrsTcUlQEZ58dntz08ssKeBGJVo0jeTOrB4wE\nLgI2AkVmNsvdiw9y3G+BuekoNBdMngx33BGmSfbsGXU1IiLJtWs6Amvd/UMAM5sC9ACKqxx3O/Ac\n0CGlFeaAffsO9N9ffRXatYu6IhGRIJmQbwaUVnq9gRD8+5nZt4Ge7n6BmeXVLcZt2+Daa2HLFli+\nHI47LuqKREQOSNUUyv8CKvfqLUXnzWrvvx82FzvxRHjlFQW8iGSfZEbyZcDJlV5/p+JrlZ0NTDEz\nA5oC3c1sj7vPrnqyYcOG7f+8oKCAgoKCwyw5OyQSYQbNkCEweDBYXvy1JiKZkEgkSCQSKTmXufuh\nDzCrD7xHuPH6MbAc6Ovua6o5fjzwvLtPP8j3vKb3ywVPPQX33BNutF58cdTViEjcmRnuXquhZI0j\neXcvN7PBwDxCe2ecu68xs0Hh2z666h+pTSG5wB1+8xsYNw4WLIDTT4+6IhGRQ6txJJ/SN8vhkfye\nPXDrreG5qy+8EJ7iJCKSCWkdyQt8+SVcc01Ywfr663DUUVFXJCKSHG1QVoONG+H886F5c5g1SwEv\nIrlFIX8I69ZBly5hFD9qFByhf/eISI5RbFVj9Wro3h2GDoWbb466GhGR2lHIH8TixXDllfDYY9C7\nd9TViIjUnkK+irlz4Sc/CXPhCwujrkZEpG7Uk6/k2WdhwIDwNCcFvIjEgUbyFSZOhPvug/nztYuk\niMSHQp7w7NUhQ8I2wXrItojESd63a558MuwF/9prCngRiZ+8HsmPGQMPPhgCvlWrqKsREUm9vA35\nMWPgX/81bDTWokXU1YiIpEdehvykSfAv/xL2hFfAi0ic5V3Iz5wZ9oJ/9VUFvIjEX16F/Pz5YYuC\nl17SXvAikh/yJuQXLYJ+/WDGDPjHf4y6GhGRzMiLKZSrV8NVV4XH9XXpEnU1IiKZE/uQLy2Fyy6D\nESPghz+MuhoRkcyKdchv2RK2C77zTu0mKSL5KbbPeN21C7p1gzPPhOHDwWr1dEQRkejV5RmvsQz5\nffvCTda9e2Hq1PBsVhGRXKUHeVcxZAhs2ACvvKKAF5H8FruQnzw5jN6XL4cjj4y6GhGRaMWqXVNU\nBJdeGjYca9s2bW8jIpJRdWnXxGZ2zcaN0KtX2HhMAS8iEsQi5HfvDgE/aBD07Bl1NSIi2SMW7Zqf\n/Qw++ihsWaCpkiISN3k9u2bqVJgzB1asUMCLiFSV0yP54mI47zyYOxfat0/ZaUVEskpe3nj96iv4\n8Y/h3/9dAS8iUp2cHcn/9KewdSs8/bTaNCISb3nXk58zB158EVatUsCLiBxKzoX8pk1w000wZQo0\naRJ1NSIi2S2n2jXu0KNHeHTfQw+lsDARkSyWN+2asWOhrAyeey7qSkREckPOjOTLysLe8AsWwD/8\nQ4oLExHJYmmfQmlmhWZWbGYlZnbvQb7fz8xWVXy8YWYp3z3m9tvhllsU8CIih6PGdo2Z1QNGAhcB\nG4EiM5vl7sWVDnsfON/dt5pZITAG6JyqImfMgHffDdsIi4hI8pLpyXcE1rr7hwBmNgXoAewPeXdf\nWun4pUCzVBW4dWsYxU+erP3hRUQOVzLtmmZAaaXXGzh0iN8IvFSXoiq7//6wR/z556fqjCIi+SOl\ns2vM7AJgINClumOGDRu2//OCggIKCgqqPd/KlTB9OqxZk7oaRUSyXSKRIJFIpORcNc6uMbPOwDB3\nL6x4fR/g7v5wlePaAdOAQndfX825kp5d4w5du8K114Z94kVE8lW6Z9cUAS3MrLmZNQT6ALOrFHAy\nIeD7Vxfwh+u550I//sYbU3E2EZH8VGO7xt3LzWwwMI/wl8I4d19jZoPCt3008ABwLPC4mRmwx907\n1raonTvhn/8ZJkyA+vVrexYREcnKxVDDh4dFT7Nn13ioiEjs1aVdk3Uhv307tGgB8+ZBu3YZKkxE\nJIvF6qEhjz4KF1yggBcRSYWsGslv3gwtW8LixdCqVcbKEhHJarEZyY8YAZdfroAXEUmVrBnJ/+Uv\n8N3vQiIBp52WsZJERLJeLEbyEyZAp04KeBGRVMqKkXx5OXz/+zB+PJx3XsbKERHJCTk/kp85E447\nDrpUu+ONiIjURlaE/H//N9x1F1it/p4SEZHqRN6uWb8ezjkHSkuhUaOMlSIikjNyul0zfnzYaVIB\nLyKSepGO5MvLoXlzePllPbtVRKQ6OTuSnzsXmjVTwIuIpEukIf/kk3DDDVFWICISb5G1a7ZtC6P4\njz6CY47JWAkiIjknJ9s1c+aEefEKeBGR9Iks5KdNg169onp3EZH8EEm7ZtcuOP54WLcurHQVEZHq\n5Vy7ZsmSsFeNAl5EJL0iCfl58+CSS6J4ZxGR/KKQFxGJsYz35L/4wmneHD77DBo2zNhbi4jkrJzq\nyRcVQfv2CngRkUzIeMgvXw4dO2b6XUVE8lMkI/kOHTL9riIi+UkjeRGRGMt4yJeXw8knZ/pdRUTy\nU8ZDvmVLPeZPRCRTMh7yJ5yQ6XcUEclfGQ/544/P9DuKiOQvhbyISIwp5EVEYkw9eRGRGNNIXkQk\nxhTyIiIxllTIm1mhmRWbWYmZ3VvNMY+Z2Voze8vMzqzuXAp5EZHMqTHkzaweMBLoBpwO9DWz1lWO\n6Q6c6u4tgUHAqOrO981v1qne2EgkElGXkDV0LQ7QtThA1yI1khnJdwTWuvuH7r4HmAL0qHJMD2Ai\ngLsvA5qY2UFvsdaL7NHh2UU/wAfoWhyga3GArkVqJBO5zYDSSq83VHztUMeUHeQYERHJMI2rRURi\nrMbH/5lZZ2CYuxdWvL4PcHd/uNIxo4AF7j614nUx0NXdP61yrsw9a1BEJEZq+/i/I5I4pghoYWbN\ngY+BPkDfKsfMBm4Dplb8pbClasDXpUgREamdGkPe3cvNbDAwj9DeGefua8xsUPi2j3b3F83sUjNb\nB+wABqa3bBERSUaN7RoREcldabnxmsrFU7mupmthZv3MbFXFxxtm1jaKOjMhmZ+LiuM6mNkeM+uV\nyfoyKcnfkQIzW2lm75jZgkzXmClJ/I78nZnNrsiKt83sugjKTDszG2dmn5rZ6kMcc/i56e4p/SD8\nxbEOaA40AN4CWlc5pjswp+LzTsDSVNeRDR9JXovOQJOKzwvz+VpUOu5V4AWgV9R1R/hz0QT4E9Cs\n4nXTqOuO8FrcDzz09XUAPgeOiLr2NFyLLsCZwOpqvl+r3EzHSD6li6dyXI3Xwt2XuvvWipdLie/6\ngmR+LgBuB54DNmWyuAxL5lr0A6a5exmAu3+W4RozJZlr4cDRFZ8fDXzu7nszWGNGuPsbwOZDHFKr\n3ExHyGvx1AHJXIvKbgReSmtF0anxWpjZt4Ge7v4EEOeZWMn8XLQCjjWzBWZWZGb9M1ZdZiVzLUYC\nbcxsI7AKuCNDtWWbWuVmMlMoJQPM7ALCrKQuUdcSof8CKvdk4xz0NTkCaA9cCPw/YImZLXH3ddGW\nFYluwEp3v9DMTgXmm1k7d98edWG5IB0hXwacXOn1dyq+VvWYv6/hmDhI5lpgZu2A0UChux/qn2u5\nLJlrcTYwxcyM0HvtbmZ73H12hmrMlGSuxQbgM3ffCew0s4XAGYT+dZwkcy0GAg8BuPt6M/sAaA38\nMSMVZo9a5WY62jX7F0+ZWUPC4qmqv6SzgQGwf0XtQRdPxUCN18LMTgamAf3dfX0ENWZKjdfC3U+p\n+PgeoS//0xgGPCT3OzIL6GJm9c2sMeFG25oM15kJyVyLD4GLASp60K2A9zNaZeYY1f8Ltla5mfKR\nvGvx1H7JXAvgAeBY4PGKEewed+8YXdXpkeS1+Ks/kvEiMyTJ35FiM5sLrAbKgdHu/m6EZadFkj8X\nvwEmVJpa+At3/yKiktPGzCYDBcC3zOwjYCjQkDrmphZDiYjEmHahFBGJMYW8iEiMKeRFRGJMIS8i\nEmMKeRGRGFPIi4jEmEJeRCTGFPIiIjH2/wEjSoYDQ5V5ewAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x106155a20>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "x = np.linspace(0, 1, num=300)\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.plot(x, np.sqrt(x))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tests/test_nbsphinx.py
+++ b/tests/test_nbsphinx.py
@@ -1,0 +1,11 @@
+import sys
+sys.path = ['..'] + sys.path
+from nbsphinx import NotebookParser
+
+
+def test_basic_parse():
+    n = NotebookParser()
+    n.parse('Basic.ipynb', 'basic.rst')
+
+if __name__ == "__main__":
+    test_basic_parse()


### PR DESCRIPTION
This implements a basic testing framework, as mentioned in #57. Going off the py.test/nose/etc testing framework, I tried to implement some basic tests in `tests/`.

My one test (below) didn't pass (threw NotJSON error) but at least the test is here now, and I'll let you work out the details.

``` python
def test_basic_parse():
    n = NotebookParser()
    n.parse('Basic.ipynb', 'basic.rst')
```
