### PR TITLE
Adding a footer template handler to add the widget state script tag

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -162,7 +162,7 @@ RST_TEMPLATE = """
 
     .. raw:: html
 
-        <script type="{{ datatype }}">{{ output.data[datatype] }}</script>
+        <script type="{{ datatype }}">{{ output.data[datatype] | json_dumps }}</script>
 {%- elif datatype == 'ansi' %}
 
     .. rst-class:: highlight
@@ -240,6 +240,20 @@ RST_TEMPLATE = """
 {{ cell.source }}
 {% endif %}
 {% endblock rawcell %}
+
+
+{% block footer %}
+
+{% if 'application/vnd.jupyter.widget-state+json' in nb.metadata.widgets %}
+
+.. raw:: html
+
+    <script type="application/vnd.jupyter.widget-state+json">
+    {{ nb.metadata.widgets['application/vnd.jupyter.widget-state+json'] | json_dumps }}
+    </script>
+{% endif %}
+{{ super() }}
+{% endblock footer %}
 """
 
 
@@ -485,6 +499,7 @@ class Exporter(nbconvert.RSTExporter):
                 'get_empty_lines': _get_empty_lines,
                 'extract_toctree': _extract_toctree,
                 'get_output_type': _get_output_type,
+                'json_dumps': json.dumps,
             })
 
     @property


### PR DESCRIPTION
With this change , we can render interactive widgets in documentation generated from nbsphinx:

Thanks a lot to @takluyver for his help in person here and @michaelpacer for the work in progress in the html convert in nbconvert.

- Adding a json.dumps step in the serialization of `+json` types
- Adding a footer script tag for the widget state if present.

![nbsphinx-screencast](https://cloud.githubusercontent.com/assets/2397974/20971580/41b0af4a-bc92-11e6-9066-d95b3282fe60.gif)
