### PR TITLE
Force docutils <0.13.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     version=__version__,
     py_modules=['nbsphinx'],
     install_requires=[
-        'docutils',
+        'docutils<0.13.1',
         'jinja2',
         'nbconvert',
         'traitlets',


### PR DESCRIPTION
Docutils 0.13.1 which was just released breaks nbsphinx because of  https://github.com/sphinx-doc/sphinx/issues/3212

The issue seems to have been fixed in sphinx master since https://github.com/sphinx-doc/sphinx/pull/3217 but until a new version of sphinx is released, we need to force `docutils<0.13.1`.