### PR TITLE
Added the hide_input option

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -91,6 +91,12 @@ RST_TEMPLATE = """
 {% endif %}
 {%- endblock any_cell %}
 
+{% block input_group -%}                                                        
+{%- if cell.metadata.hide_input -%} 
+{%- else -%} 
+{{ super() }} 
+{%- endif -%} 
+{% endblock input_group %}
 
 {% block input -%}
 .. nbinput:: {% if cell.metadata.magics_language -%}


### PR DESCRIPTION
This partially covers #81 and #6. 
With `"hide_input": true` as cell metadata the cell input is hidden but not the output.

This solution is not very elegant since the "Out[10]" is still there
![untitled](https://cloud.githubusercontent.com/assets/16083414/21381622/a1d96a86-c75c-11e6-8e91-8d7844c6641a.png)
 