### PR TITLE
Add 'supported' attribute to NotebookParser

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -563,6 +563,8 @@ class NotebookParser(rst.Parser):
 
     """
 
+    supported = ()
+
     def get_transforms(self):
         """List of transforms for documents parsed by this parser."""
         return rst.Parser.get_transforms(self) + [


### PR DESCRIPTION
This adds an empty attribute `supported` to the `NotebookParser` class so that Sphinx's `get_parser_type()` uses this parser for .ipynb files instead of thinking they are restructured text.

See also https://github.com/spatialaudio/nbsphinx/issues/38#issuecomment-271595602