### PR TITLE
Make in memory template name match it's declaration

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -497,7 +497,7 @@ class Exporter(nbconvert.RSTExporter):
         self._allow_errors = allow_errors
         self._timeout = timeout
         self._codecell_lexer = codecell_lexer
-        loader = jinja2.DictLoader({'nbsphinx-rst.tpl': RST_TEMPLATE})
+        loader = jinja2.DictLoader({'nbsphinx-rst': RST_TEMPLATE})
         super(Exporter, self).__init__(
             template_file='nbsphinx-rst', extra_loaders=[loader],
             config= traitlets.config.Config(


### PR DESCRIPTION
With nbconvert 5.1.1+ in-memory templates need to be declared with the same "file name" as they are then invoked with. This relates to the changes made to allow in memory templates more generally because it's fine now for them to have no extension while being loaded. 

Right now nbsphinx is looking for `nbsphinx-rst` when it has loaded `nbsphinx-rst.tpl`. 

This fix should address the issue with nbsphinx and nbconvert 5.1.1 that is currently stopping docs that use nbsphinx from building. I've tested it locally on python2 and 3 and it makes the nbconvert docs build again. 