### PR TITLE
Specify template name including extension

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -499,7 +499,7 @@ class Exporter(nbconvert.RSTExporter):
         self._codecell_lexer = codecell_lexer
         loader = jinja2.DictLoader({'nbsphinx-rst.tpl': RST_TEMPLATE})
         super(Exporter, self).__init__(
-            template_file='nbsphinx-rst', extra_loaders=[loader],
+            template_file='nbsphinx-rst.tpl', extra_loaders=[loader],
             config= traitlets.config.Config(
                 {'HighlightMagicsPreprocessor': {'enabled': True}}),
             filters={


### PR DESCRIPTION
I think this should work on all versions of nbconvert.

Closes gh-93
Alternative to gh-94