### PR TITLE
Add jupyter-js-widgets embedder javascript

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -1278,6 +1278,9 @@ def setup(app):
     app.add_node(AdmonitionNode,
                  html=(visit_admonition_html, depart_admonition_html),
                  latex=(visit_admonition_latex, depart_admonition_latex))
+
+    app.add_javascript('https://unpkg.com/jupyter-js-widgets@^2.1.4/dist/embed.js')
+
     app.connect('builder-inited', builder_inited)
     app.connect('html-page-context', html_page_context)
     app.connect('html-collect-pages', html_collect_pages)


### PR DESCRIPTION
We have just released ipywidgets 6.0.

This complete the work on the rendering of jupyter widgets in nbsphinx-generated docs.

Closes #84.