### PR TITLE
LaTeX: Add \relax at the end of ANSI cells

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -179,6 +179,7 @@ RST_TEMPLATE = """
         \\begin{OriginalVerbatim}[commandchars=\\\\\\{\\}]
 {{ output.data[datatype] | ansi2latex | indent | indent }}
         \\end{OriginalVerbatim}
+        \\relax
 {% else %}
 
     .. nbwarning:: Data type cannot be displayed: {{ datatype }}


### PR DESCRIPTION
@mgeier Actually this is pull request #106. I was a little unfamiliar with GitHub's work flow and I withdrew a commit so #106 closed.

Sorry about this.