### PR TITLE
LaTeX: Improve handling of raw cells.

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -230,7 +230,6 @@ RST_TEMPLATE = """
 
 .. raw:: latex
 
-    %
 {{ cell.source | indent }}
 {%- elif raw_mimetype == 'text/html' %}
 .. raw:: html
@@ -239,7 +238,6 @@ RST_TEMPLATE = """
 {%- elif raw_mimetype == 'text/latex' %}
 .. raw:: latex
 
-    %
 {{ cell.source | indent }}
 {%- elif raw_mimetype == 'text/markdown' %}
 {{ cell.source | markdown2rst }}


### PR DESCRIPTION
* Raw cells with "None" type will now be on their own paragraph in LaTeX
* Raw cells with "LaTeX" will not, but the user can add blank lines
* More docs