### PR TITLE
Use sphinx.util.status_iterator()

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -1174,8 +1174,9 @@ def html_collect_pages(app):
     files = set()
     for file_list in getattr(app.env, 'nbsphinx_files', {}).values():
         files.update(file_list)
-    for file in app.status_iterator(files, 'copying linked files... ',
-                                    sphinx.util.console.brown, len(files)):
+    for file in sphinx.util.status_iterator(files, 'copying linked files... ',
+                                            sphinx.util.console.brown,
+                                            len(files)):
         target = os.path.join(app.builder.outdir, file)
         sphinx.util.ensuredir(os.path.dirname(target))
         try:


### PR DESCRIPTION
... instead of app.status_iterator(), which was deprecated in Sphinx 1.6