### PR TITLE
Interpret links to reST sub-sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 dist/
 nbsphinx.egg-info/
 .ipynb_checkpoints/
+.python-version

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -246,7 +246,13 @@
     "[A reStructuredText file](a-normal-rst-file.rst)\n",
     "```\n",
     "\n",
-    "Links to sub-sections are not (yet?) possible."
+    "Links to sub-sections are also possible. Example: [Sphinx Directives](a-normal-rst-file.html#sphinx-directives-for-info-warning-boxes)",
+    "\n",
+    "This was created with:\n",
+    "\n",
+    "```\n",
+    "[Sphinx Directives](a-normal-rst-file.rst#sphinx-directives-for-info-warning-boxes)\n",
+    "```\n"
    ]
   },
   {

--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -1017,6 +1017,12 @@ class ProcessLocalLinks(docutils.transforms.Transform):
                 reftype = 'ref'
                 refdomain = 'std'
             else:
+                # .rst element reference in .ipynb, for instance:
+                # (A section)[document.rst#a-section]
+                if '.rst#' in uri:
+                    uri = uri.replace('.rst#', '.html#')
+                    node.replace_attr('refuri', uri, force=True)
+                    continue
                 file = os.path.normpath(
                     os.path.join(os.path.dirname(env.docname), unquoted_uri))
                 if not os.path.isfile(os.path.join(env.srcdir, file)):


### PR DESCRIPTION
This pull-request provides a fix to allow links from ipynb to reST sub-sections.
Documentation has been updated accordingly, with an example.