### PR TITLE
Allow links to Python entities

### DIFF
--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -266,6 +266,21 @@
     "The linked files are automatically copied to the HTML output directory.\n",
     "For LaTeX output, no link is created."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Links to Python Domain\n",
+    "\n",
+    "Links to Python modules, classes, functions, etc. (anything in the [Python domain](http://www.sphinx-doc.org/en/stable/domains.html#the-python-domain)) can be made like this:\n",
+    "\n",
+    "```\n",
+    "[py:meth:my_module.MyClass.my_method](my_method)\n",
+    "```\n",
+    "\n",
+    "This can be useful when paired with the `autodoc` Sphinx extension.\n",
+   ]
   }
  ],
  "metadata": {

--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -1016,6 +1016,12 @@ class ProcessLocalLinks(docutils.transforms.Transform):
                 target_ext = uri[idx:]
                 reftype = 'ref'
                 refdomain = 'std'
+            elif uri.lower().startswith('py:'):
+                target_ext = ''
+                idx = 3 + uri[3:].find(':')
+                target = uri[idx+1:]
+                reftype = uri[3:idx]
+                refdomain = 'py'
             else:
                 file = os.path.normpath(
                     os.path.join(os.path.dirname(env.docname), unquoted_uri))
@@ -1033,8 +1039,11 @@ class ProcessLocalLinks(docutils.transforms.Transform):
                 env.nbsphinx_files.setdefault(env.docname, []).append(file)
                 continue  # We're done here
 
-            target_docname = os.path.normpath(
-                os.path.join(os.path.dirname(env.docname), target))
+            if uri.lower().startswith('py:'):
+                target_docname = env.domaindata['py']['objects'][target][0]
+            else:
+                target_docname = os.path.normpath(
+                    os.path.join(os.path.dirname(env.docname), target))
             if target_docname in env.found_docs:
                 if target_ext:
                     target = target_docname + target_ext


### PR DESCRIPTION
This PR lets you create links to things in the Python sphinx domain like you would in ReST. So for example:

    [py:module:mymodule](mymodule)

This is especially helpful when paired with `autodoc`. Works for html and LaTeX.
Related to #130.