### PR TITLE
Hotfix for CreateSectionLabels with duplicates

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -1094,7 +1094,11 @@ class CreateSectionLabels(docutils.transforms.Transform):
 
         # Create labels for domain-specific object signatures
         for sig in self.document.traverse(sphinx.addnodes.desc_signature):
-            title = sig['ids'][0]
+            try:
+                title = sig['ids'][0]
+            except IndexError:
+                # Object has same name as another, so skip it
+                continue
             link_id = title.replace(' ', '-')
             sig['ids'] = [link_id]
             label = env.docname + file_ext + '#' + link_id


### PR DESCRIPTION
It seems that if there are domain objects with the same name in a single document, Sphinx only creates a link for the first one, so the 'ids' of the subsequent ones will be empty. We only need to create a label for the first one, as the others aren't linkable anyway.

Fixes #142.