### PR TITLE
Please make the build reproducible.

### DIFF
--- a/nbsphinx.py
+++ b/nbsphinx.py
@@ -150,13 +150,12 @@ RST_TEMPLATE = """
 
 {{ output.data['text/html'] | indent | indent }}
 {%- elif datatype == 'application/javascript' %}
-{% set div_id = uuid4() %}
 
     .. raw:: html
 
-        <div id="{{ div_id }}"></div>
+        <div></div>
         <script type="text/javascript">
-        var element = document.getElementById('{{ div_id }}');
+        var element = document.currentScript.previousSibling.previousSibling;
 {{ output.data['application/javascript'] | indent | indent }}
         </script>
 {%- elif datatype.startswith('application') and datatype.endswith('+json') %}


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that nbsphinx could not be built reproducibly.

Patch attached that uses different Javascript to get the sibling
``<div/>`` element instead of generating a (random) UUID and putting
that in the DOM.

 [0] https://reproducible-builds.org/