### PR TITLE
Use nested_parse_with_titles() instead of nested_parse()

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -784,8 +784,8 @@ class NbOutput(rst.Directive):
         if outputtype == 'rst':
             classes = [self.options.get('class', ''), 'output_area']
             output_area = docutils.nodes.container(classes=classes)
-            self.state.nested_parse(self.content, self.content_offset,
-                                    output_area)
+            sphinx.util.nodes.nested_parse_with_titles(
+                self.state, self.content, output_area)
             container += output_area
         else:
             text = '\n'.join(self.content.data)


### PR DESCRIPTION
See #152.

Note that the heading levels are kinda "reset" inside the reST output cell.
The first heading inside the output cell will have the highest level (one level lower than the surrounding text), the next one the next lower etc., regardless of the actual heading level you selected by choosing the number of `#` characters!

Try putting something like this into the Markdown output cell:

```markdown
## level 1

# level 2
```

... and you'll see that the heading levels are reversed.
This is due to the way how Sphinx/docutils handles heading levels.

I think this behavior may be the one we want, but if that's not the desired behavior, we could try to do something similar as is done in the `only` directive, see the following links:

https://github.com/sphinx-doc/sphinx/issues/795
https://github.com/sphinx-doc/sphinx/commit/729565b7a91ac2d07031aabce435b9030496934a
https://github.com/sphinx-doc/sphinx/issues/886
https://github.com/sphinx-doc/sphinx/issues/1115
https://github.com/sphinx-doc/sphinx/commit/6654687ec19a446388b7799c1e11b361921c4f7b