### PR TITLE
Check for extra line in code blocks for Sphinx >= 1.6.6

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -1302,6 +1302,9 @@ def depart_code_latex(self, node):
     out = []
     assert lines[0] == ''
     out.append(lines[0])
+    if lines[1].startswith(r'\fvset{'):  # Sphinx >= 1.6.6
+        out.append(lines[1])
+        del lines[1]
     if lines[1].startswith(r'\begin{sphinxVerbatim}'):  # Sphinx >= 1.5
         out.append(lines[1].replace('sphinxVerbatim', 'Verbatim'))
     elif lines[1].startswith(r'\begin{Verbatim}'):  # Sphinx < 1.5


### PR DESCRIPTION
I've missed that before, although I was personally informed on time:

https://github.com/sphinx-doc/sphinx/pull/4285#discussion_r155945321

Those were the changes in Sphinx:

https://github.com/sphinx-doc/sphinx/commit/70f8d4ddfcd7ee0a1873ed5a9fbde283a74f818c

https://github.com/sphinx-doc/sphinx/commit/314f5291d4902b8a59afe602dc209132ddd74b3b