### PR TITLE
strip only newlines instead of all whitespace

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -131,7 +131,7 @@ RST_TEMPLATE = """
 {%- if datatype == 'text/plain' -%}
 {{ insert_empty_lines(output.data[datatype]) }}
 
-{{ output.data[datatype].strip(\n) | indent }}
+{{ output.data[datatype].strip('\n') | indent }}
 {%- elif datatype in ['image/svg+xml', 'image/png', 'image/jpeg', 'application/pdf'] %}
 
     .. image:: {{ output.metadata.filenames[datatype] | posix_path }}


### PR DESCRIPTION
I think it was always the intention to work like that and this bug is just a typo... I could be wrong obviously...

Attached is a small test case. It works fine after the patch.
[leading_blanks_testcase.zip](https://github.com/spatialaudio/nbsphinx/files/2352901/leading_blanks_testcase.zip)

Btw, nbconvert works correctly on this.