### PR TITLE
Make sure nbinput and nboutput directives are closed in reST source

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -111,6 +111,7 @@ RST_TEMPLATE = """
 
 {{ cell.source.strip('\n') | indent }}
 {%- endif %}
+..{# Empty comment to make sure the directive is closed #}
 {% endblock input %}
 
 
@@ -187,6 +188,7 @@ RST_TEMPLATE = """
 
     .. nbwarning:: Data type cannot be displayed: {{ datatype }}
 {%- endif %}
+..{# Empty comment to make sure the directive is closed #}
 {% endmacro %}
 
 


### PR DESCRIPTION
Insert empty comments to make sure the directives are closed (as shown in http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#block-quotes) in case they are followed by a block quote.

This should fix #203.