### PR TITLE
Don't pass an empty kernel name by default to ExecutePreprocessor

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -573,10 +573,12 @@ class Exporter(nbconvert.RSTExporter):
             allow_errors = nbsphinx_metadata.get(
                 'allow_errors', self._allow_errors)
             timeout = nbsphinx_metadata.get('timeout', self._timeout)
-            pp = nbconvert.preprocessors.ExecutePreprocessor(
-                kernel_name=self._kernel_name,
-                extra_arguments=self._execute_arguments,
-                allow_errors=allow_errors, timeout=timeout)
+            preprocess_args = {"extra_arguments":self._execute_arguments,
+                               "allow_errors": allow_errors,
+                               "timeout": timeout}
+            if self._kernel_name != "":
+                preprocess_args['kernel_name'] = self._kernel_name
+            pp = nbconvert.preprocessors.ExecutePreprocessor(**preprocess_args)
             nb, resources = pp.preprocess(nb, resources)
 
         # Call into RSTExporter


### PR DESCRIPTION
This uses the preferred pattern as described in https://github.com/jupyter/nbconvert/pull/886 for getting access to the default behaviour of deferring to the notebook's metadata by not passing in a `kernel_name` at all (rather than by passing in an empty kernel name).

However, https://github.com/jupyter/nbconvert/pull/886 should make the code today work.