### PR TITLE
DOC: sphinx.quickstart -> sphinx.cmd.quickstart

### DIFF
--- a/doc/usage.ipynb
+++ b/doc/usage.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "In the directory with your notebook files, run this command (assuming you have [Sphinx](http://sphinx-doc.org/) installed already):\n",
     "\n",
-    "    python3 -m sphinx.quickstart\n",
+    "    python3 -m sphinx.cmd.quickstart\n",
     "\n",
     "Answer the questions that appear on the screen. In case of doubt, just press the `<Return>` key repeatedly to take the default values.\n",
     "\n",


### PR DESCRIPTION
This was changed in Sphinx version 1.7,
see https://github.com/sphinx-doc/sphinx/pull/4077.