### PR TITLE
Disable pandoc's "implicit_figures" extension

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -911,7 +911,10 @@ def markdown2rst(text):
         json_data = json.loads(text, object_hook=rawlatex2math_hook)
         return json.dumps(json_data)
 
-    rststring = pandoc(text, 'markdown', 'rst', filter_func=rawlatex2math)
+    input_format = 'markdown'
+    input_format += '-implicit_figures'
+
+    rststring = pandoc(text, input_format, 'rst', filter_func=rawlatex2math)
     return re.sub(r'^\n( *)\x0e:nowrap:\x0f$',
                   r'\1:nowrap:',
                   rststring,


### PR DESCRIPTION
Previously, the "alt" text of an image that was in a paragraph on its own was used as a figure caption.
This is the default `pandoc` behavior but not at all the behavior of the Notebook app.

This PR disables this.

If anybody relied on this behavior in the past, please speak up!