### PR TITLE
LaTeX: re-design code cells

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -352,12 +352,12 @@ div.nblast {
 
 /* input prompt */
 div.nbinput div.prompt pre {
-    color: #303F9F;
+    color: #307FC1;
 }
 
 /* output prompt */
 div.nboutput div.prompt pre {
-    color: #D84315;
+    color: #BF5B3D;
 }
 
 /* all prompts */
@@ -403,9 +403,9 @@ div.nboutput div.output_area {
 
 /* input area */
 div.nbinput div.input_area {
-    border: 1px solid #cfcfcf;
+    border: 1px solid #e0e0e0;
     border-radius: 2px;
-    background: #f7f7f7;
+    background: #f5f5f5;
 }
 
 /* override MathJax center alignment in output cells */


### PR DESCRIPTION
Inspired by https://github.com/t-makaro/nb_pdf_template, I've tried to make the LaTeX version of the code cells a bit prettier. The colors are taken from JupyterLab.

As a positive side effect, this now uses the `sphinxVerbatim` including its line-break and page-break features!

A temporary example PDF file can be found there: https://readthedocs.org/projects/nbsphinx/downloads/pdf/latex-codecells/ (once this PR is merged this will be in https://readthedocs.org/projects/nbsphinx/downloads/pdf/latest/).

There are still a few rough edges, I'd love to hear some ideas for improvements!