### PR TITLE
DOC: alternative try to improve the "separators" between notebooks in LaTeX output

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,7 +4,7 @@
 # Use sphinx-quickstart to create your own conf.py file!
 # After that, you have to edit a few things.  See below.
 
-# Select nbsphinx and, if needed, add a math extension (mathjax or pngmath):
+# Select nbsphinx and, if needed, add a math extension (mathjax or imgmath):
 extensions = [
     'nbsphinx',
     'sphinx.ext.mathjax',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,20 +64,30 @@ nbsphinx_prolog = r"""
 .. raw:: latex
 
     \vfil\penalty-1\vfilneg
-    \vspace{\baselineskip}
-    \textcolor{gray}{The following section was generated from
-    \texttt{\strut{}{{ docname }}}\\[-0.5\baselineskip]
-    \noindent\rule{\textwidth}{0.4pt}}
-    \vspace{-2\baselineskip}
+    \par
+    \smallskip
+    \noindent\textcolor{gray}{\scriptsize
+    The following section was generated from
+    \sphinxcode{\sphinxupquote{\strut{}{{ docname | escape_latex }}}}.}
+    \par\nointerlineskip\kern-1ex
+    \noindent\textcolor{gray}{\rule{\textwidth}{0.4pt}}
+    \par\unskip\kern-1ex
+    \makeatletter\@setminipage\makeatother
 """
 
 # This is processed by Jinja2 and inserted after each notebook
 nbsphinx_epilog = r"""
 .. raw:: latex
 
-    \textcolor{gray}{\noindent\rule{\textwidth}{0.4pt}\\
-    \hbox{}\hfill End of
-    \texttt{\strut{}{{ env.doc2path(env.docname, base='doc') }}}}
+    \makeatletter\@minipagefalse\makeatother
+    \par\nointerlineskip
+    \noindent\textcolor{gray}{\rule{\textwidth}{0.4pt}}
+    \par\nointerlineskip\kern-1ex
+    \noindent\textcolor{gray}{\scriptsize\hfill
+    End of \sphinxcode{\sphinxupquote{\strut
+    {{ env.doc2path(env.docname, base='doc') | escape_latex }}}}.}
+    \par
+    \smallskip
     \vfil\penalty-1\vfilneg
 """
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -63,32 +63,39 @@ nbsphinx_prolog = r"""
 
 .. raw:: latex
 
-    \vfil\penalty-1\vfilneg
     \par
-    \smallskip
-    \noindent\textcolor{gray}{\scriptsize
-    The following section was generated from
-    \sphinxcode{\sphinxupquote{\strut{}{{ docname | escape_latex }}}}.}
-    \par\nointerlineskip\kern-1ex
-    \noindent\textcolor{gray}{\rule{\textwidth}{0.4pt}}
-    \par\unskip\kern-1ex
-    \makeatletter\@setminipage\makeatother
+    \makeatletter
+      \addpenalty\@secpenalty
+      \@tempskipa 2.3ex \@plus .2ex\relax
+      \addvspace\@tempskipa
+    {\color{gray}\scriptsize
+    \vbox{\parskip\z@skip\hsize\linewidth
+    \noindent The following section was generated from
+    \sphinxcode{\sphinxupquote{\strut{}{{ docname | escape_latex }}}}.\par
+    \kern -1ex % this 1ex depends on \scriptsize value
+    \noindent\rule{\hsize}{0.4pt}%
+    \par
+    % add here \kern for negative or positive extra vertical space if needed
+    }}\@nobreaktrue\everypar{\@nobreakfalse}\nobreak
+    \makeatother
 """
 
 # This is processed by Jinja2 and inserted after each notebook
 nbsphinx_epilog = r"""
 .. raw:: latex
 
-    \makeatletter\@minipagefalse\makeatother
-    \par\nointerlineskip
-    \noindent\textcolor{gray}{\rule{\textwidth}{0.4pt}}
-    \par\nointerlineskip\kern-1ex
-    \noindent\textcolor{gray}{\scriptsize\hfill
-    End of \sphinxcode{\sphinxupquote{\strut
-    {{ env.doc2path(env.docname, base='doc') | escape_latex }}}}.}
     \par
-    \smallskip
-    \vfil\penalty-1\vfilneg
+    \makeatletter
+    {\color{gray}%
+    \scriptsize
+    \nobreak\vtop{%
+    \kern -1ex
+    \parskip\z@skip\hsize\linewidth\parfillskip\z@skip
+    \noindent\rule{\hsize}{0.4pt}\par
+    \noindent\hfill End of \sphinxcode{\sphinxupquote{\strut
+    {{ env.doc2path(env.docname, base='doc') | escape_latex }}}}.\par
+    }}\makeatother
+    \bigskip % or whatever is needed
 """
 
 # Input prompt for code cells. "%s" is replaced by the execution count.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -69,15 +69,13 @@ nbsphinx_prolog = r"""
       \addpenalty\@secpenalty
       \@tempskipa 2.3ex \@plus .2ex\relax
       \addvspace\@tempskipa
-    {\color{gray}\scriptsize
-    \vbox{\parskip\z@skip\hsize\linewidth
+    {\color{gray}\parskip\z@skip\scriptsize
     \noindent The following section was generated from
-    \sphinxcode{\sphinxupquote{\strut{}{{ docname | escape_latex }}}}.\par
-    \kern -1ex
-    \noindent\rule{\hsize}{0.4pt}%
+    \sphinxcode{\sphinxupquote{\strut{}{{ docname | escape_latex }}}}\dotfill
     \par
-    }}\@nobreaktrue\everypar{\@nobreakfalse\everypar{}}\nobreak
+    }\@nobreaktrue\everypar{\@nobreakfalse\everypar{}}\nobreak
     \makeatother
+    \vskip-\parskip\nobreak
 """
 
 # This is processed by Jinja2 and inserted after each notebook
@@ -86,13 +84,10 @@ nbsphinx_epilog = r"""
 
     \par
     \makeatletter
-    {\color{gray}\scriptsize
-    \nobreak\vtop{\kern -1ex
-    \parskip\z@skip\hsize\linewidth\parfillskip\z@skip
-    \noindent\rule{\hsize}{0.4pt}\par
-    \noindent\hfill End of \sphinxcode{\sphinxupquote{\strut
-    {{ env.doc2path(env.docname, base='doc') | escape_latex }}}}.\par
-    }}\makeatother
+    {\color{gray}\parskip\z@skip\scriptsize
+    \nobreak\noindent\dotfill\sphinxcode{\sphinxupquote{\strut
+    {{ env.doc2path(env.docname, base='doc') | escape_latex }}}} ends here.\par
+    }\makeatother
     \kern-\baselineskip
     \penalty-9999
     \kern\baselineskip

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -64,6 +64,7 @@ nbsphinx_prolog = r"""
 .. raw:: latex
 
     \par
+    \needspace{3\baselineskip}
     \makeatletter
       \addpenalty\@secpenalty
       \@tempskipa 2.3ex \@plus .2ex\relax
@@ -72,11 +73,10 @@ nbsphinx_prolog = r"""
     \vbox{\parskip\z@skip\hsize\linewidth
     \noindent The following section was generated from
     \sphinxcode{\sphinxupquote{\strut{}{{ docname | escape_latex }}}}.\par
-    \kern -1ex % this 1ex depends on \scriptsize value
+    \kern -1ex
     \noindent\rule{\hsize}{0.4pt}%
     \par
-    % add here \kern for negative or positive extra vertical space if needed
-    }}\@nobreaktrue\everypar{\@nobreakfalse}\nobreak
+    }}\@nobreaktrue\everypar{\@nobreakfalse\everypar{}}\nobreak
     \makeatother
 """
 
@@ -86,16 +86,17 @@ nbsphinx_epilog = r"""
 
     \par
     \makeatletter
-    {\color{gray}%
-    \scriptsize
-    \nobreak\vtop{%
-    \kern -1ex
+    {\color{gray}\scriptsize
+    \nobreak\vtop{\kern -1ex
     \parskip\z@skip\hsize\linewidth\parfillskip\z@skip
     \noindent\rule{\hsize}{0.4pt}\par
     \noindent\hfill End of \sphinxcode{\sphinxupquote{\strut
     {{ env.doc2path(env.docname, base='doc') | escape_latex }}}}.\par
     }}\makeatother
-    \bigskip % or whatever is needed
+    \kern-\baselineskip
+    \penalty-9999
+    \kern\baselineskip
+    \bigskip
 """
 
 # Input prompt for code cells. "%s" is replaced by the execution count.

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -739,16 +739,14 @@ class NotebookParser(rst.Parser):
         if resources.get('nbsphinx_orphan', False):
             rst.Parser.parse(self, ':orphan:', document)
         if env.config.nbsphinx_prolog:
-            rst.Parser.parse(
-                self,
-                jinja2.Template(env.config.nbsphinx_prolog).render(env=env),
-                document)
+            prolog = exporter.environment.from_string(
+                env.config.nbsphinx_prolog).render(env=env)
+            rst.Parser.parse(self, prolog, document)
         rst.Parser.parse(self, rststring, document)
         if env.config.nbsphinx_epilog:
-            rst.Parser.parse(
-                self,
-                jinja2.Template(env.config.nbsphinx_epilog).render(env=env),
-                document)
+            epilog = exporter.environment.from_string(
+                env.config.nbsphinx_epilog).render(env=env)
+            rst.Parser.parse(self, epilog, document)
 
 
 class NotebookError(sphinx.errors.SphinxError):


### PR DESCRIPTION
I kept the first three commits of #219.

Some constructs in LaTeX make it impossible (afaik) to prevent a pagebreak: once a negative penalty is in the vertical list, one can not get rid of it. Lists from LaTeX2e and "framed" environments from framed.sty encourage breaks before and after. The only ways to prevent a page-break after a frame are:

- hack into `\fb@afterframe` to prevent insertion of `\penalty-30`,
- or make the stuff one wants absolutely on same page a part of the framing itself.

A `sphinxVerbatim` additionally encapsulates the `framed` in a `trivlist`. The `trivlist` adds it own negative penalty (of value -51).

A somewhat intimidating idea would be, if it is known notebook ends with  a code cell to use not `sphinxVerbatim` but `sphinxLastVerbatim` where the latter would be wrapper hacking into both the `trivlist` and the `framed.sty` code to prevent insertion of negative penalties before the closing rule and "End of sentence...".

Thus, the prevsent PR is better for starting a notebook than for ending one. For "starting" the code tries to emulate the code for `\section` which encourages a pagebreak before and discourages after it. For "ending the notebook" we have mainly the problems listed above.

The main issue in LaTeX is that (afaik) once a structure as decided to make a pagebreak favourable it is very difficult (and I believe impossible) to undo that with 100% certainty.

(the only way is to gather the whole material in a big vbox and vsplit it later... the kind of things framed.sty or tcolorbox do, and nesting is very very problematic then)

side note: I did not manage to test my PR on nbsphinx doc, I get some 

```
File "/.../lib/python3.6/site-packages/jinja2/lexer.py", line 739, in tokeniter
    name, filename)jinja2.exceptions.TemplateSyntaxError: unexpected char '\\' at 103
```

when trying

```
$ python3 setup.py build_sphinx -b latex
```

As a result perhaps the relative vertical location of `The following section...` and `End of...` with respect to rule is perhaps not the good one.