### PR TITLE
Get sizes from image files for better LaTeX output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ matrix:
   - env: ADDITIONAL_COMMAND="python -m sphinx doc/ doc/_build/ -b linkcheck"
 
   # a few older Sphinx releases using default Python version
-  - env: SPHINX="==1.3.2 docutils<0.13.1"
-  - env: SPHINX="==1.3.6 docutils<0.13.1"
+  - env: SPHINX="==1.4.0 docutils<0.13.1"
   - env: SPHINX="==1.4.9 docutils<0.13.1"
   - env: SPHINX="==1.5.0 docutils<0.13.1"
   - env: SPHINX="==1.5.1"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,9 @@ highlight_language = 'none'
 # Don't add .txt suffix to source files (available for Sphinx >= 1.5):
 html_sourcelink_suffix = ''
 
+# Work-around until https://github.com/sphinx-doc/sphinx/issues/4229 is solved:
+html_scaled_image_link = False
+
 # Execute notebooks before conversion: 'always', 'never', 'auto' (default)
 #nbsphinx_execute = 'never'
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'nbconvert!=5.4',
         'traitlets',
         'nbformat',
-        'sphinx>=1.3.2',
+        'sphinx>=1.4',
     ],
     author='Matthias Geier',
     author_email='Matthias.Geier@gmail.com',

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -720,6 +720,7 @@ class NotebookParser(rst.Parser):
             CreateNotebookSectionAnchors,
             ReplaceAlertDivs,
             CopyLinkedFiles,
+            GetSizeFromImages,
         ]
 
     def parse(self, inputstring, document):
@@ -1371,6 +1372,23 @@ class CopyLinkedFiles(docutils.transforms.Transform):
             if not hasattr(env, 'nbsphinx_files'):
                 env.nbsphinx_files = {}
             env.nbsphinx_files.setdefault(env.docname, []).append(file)
+
+
+class GetSizeFromImages(docutils.transforms.Transform):
+    """Get size from images and store it as node attributes."""
+
+    default_priority = 500  # Doesn't really matter?
+
+    def apply(self):
+        env = self.document.settings.env
+        for node in self.document.traverse(docutils.nodes.image):
+            if 'width' not in node and 'height' not in node:
+                uri = node['uri']
+                srcdir = os.path.dirname(env.doc2path(env.docname))
+                size = sphinx.util.images.get_image_size(
+                        os.path.join(srcdir, uri))
+                if size is not None:
+                    node['width'], node['height'] = map(str, size)
 
 
 def builder_inited(app):

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -136,6 +136,16 @@ RST_TEMPLATE = """
 {%- elif datatype in ['image/svg+xml', 'image/png', 'image/jpeg', 'application/pdf'] %}
 
     .. image:: {{ output.metadata.filenames[datatype] | posix_path }}
+{%- if datatype in output.metadata %}
+{%- set width = output.metadata[datatype].width %}
+{%- if width %}
+        :width: {{ width }}
+{%- endif %}
+{%- set height = output.metadata[datatype].height %}
+{%- if height %}
+        :height: {{ height }}
+{% endif %}
+{% endif %}
 {%- elif datatype in ['text/markdown'] %}
 
 {{ output.data['text/markdown'] | markdown2rst | indent }}


### PR DESCRIPTION
See #12.

This mostly works, but there are a few remaining problems:

* [ ] Getting the size doesn't seem to work for PDF images

* [ ] `data:` URIs don't work

* [x] images are unnecessarily turned into links in HTML output (see https://github.com/sphinx-doc/sphinx/issues/4229 and [the `html_scaled_image_link` option](http://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_scaled_image_link)). For now, I've used `html_scaled_image_link` in the docs.

* [ ] The maximum size is not constrained (`nbconvert` does that). `\sphinxincludegraphics` has this feature built-in, but it works only if no height/width is given (see `sphinx.sty`).