### PR TITLE
DOC: Mention the "raises-exception" cell tag

### DIFF
--- a/doc/allow-errors-per-cell.ipynb
+++ b/doc/allow-errors-per-cell.ipynb
@@ -51,7 +51,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following code cell is executed although the previous cell raised an exception."
+    "The following code cell is executed even though the previous cell raised an exception."
    ]
   },
   {
@@ -61,6 +61,24 @@
    "outputs": [],
    "source": [
     "'no problem'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "**Note:**\n",
+    "\n",
+    "The behavior of the `raises-exception` tag doesn't match its name.\n",
+    "While it does *allow* exceptions,\n",
+    "it does not check if an exception is actually raised!\n",
+    "\n",
+    "This will hopefully be fixed at some point,\n",
+    "see https://github.com/jupyter/nbconvert/issues/730.\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/doc/allow-errors-per-cell.ipynb
+++ b/doc/allow-errors-per-cell.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the `nbsphinx` documentation: http://nbsphinx.readthedocs.io/."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ignoring Errors on a Per-Cell Basis\n",
+    "\n",
+    "Instead of ignoring errors for all notebooks or for some selected notebooks (see [the previous notebook](allow-errors.ipynb)), you can be more fine-grained and just allow errors on certain code cells by tagging them with the `raises-exception` tag."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "'no problem'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following code cell has the `raises-exception` tag."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "problem"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following code cell is executed although the previous cell raised an exception."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "'no problem'"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4+"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/doc/allow-errors.ipynb
+++ b/doc/allow-errors.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "Normally, if an exception is raised while executing a notebook, the Sphinx build process is stopped immediately.\n",
     "\n",
-    "If a notebook contains errors on purpose (or if you are too lazy to fix them right now), you have three options:\n",
+    "If a notebook contains errors on purpose (or if you are too lazy to fix them right now), you have four options:\n",
     "\n",
     "1. Manually execute the notebook in question and save the results, see [the pre-executed example notebook](pre-executed.ipynb).\n",
     "\n",
@@ -33,7 +33,9 @@
     "   },\n",
     "   ```\n",
     "\n",
-    "This very notebook is an example for the last option.\n",
+    "4. Allow errors on a per-cell basis using the `raises-exception` tag, see [Ignoring Errors on a Cell-by-Cell Basis](allow-errors-per-cell.ipynb).\n",
+    "\n",
+    "This very notebook is an example for the third option.\n",
     "The results of the following code cells are not stored within the notebook, therefore it is executed during the Sphinx build process.\n",
     "Since the above-mentioned `allow_errors` flag is set in this notebook's metadata, all cells are executed although most of them cause an exception."
    ]

--- a/doc/executing-notebooks.ipynb
+++ b/doc/executing-notebooks.ipynb
@@ -30,6 +30,7 @@
     "* [Pre-Executing Notebooks](pre-executed.ipynb)\n",
     "* [Explicitly Dis-/Enabling Notebook Execution](never-execute.ipynb)\n",
     "* [Ignoring Errors](allow-errors.ipynb)\n",
+    "* [Ignoring Errors on a Per-Cell Basis](allow-errors-per-cell.ipynb)\n",
     "* [Cell Execution Timeout](timeout.ipynb)"
    ]
   }
@@ -50,9 +51,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1+"
+   "version": "3.7.4+"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/doc/pre-executed.ipynb
+++ b/doc/pre-executed.ipynb
@@ -123,7 +123,7 @@
     "If an exception is raised during the Sphinx build process, it is stopped (the build process, not the exception!).\n",
     "If you want to show to your audience how an exception looks like, you have two choices:\n",
     "\n",
-    "1. Allow errors -- either generally or on a per-notebook basis -- see [Ignoring Errors](allow-errors.ipynb).\n",
+    "1. Allow errors -- either generally or on a per-notebook or per-cell basis -- see [Ignoring Errors](allow-errors.ipynb) ([per cell](allow-errors-per-cell.ipynb)).\n",
     "\n",
     "1. Execute the notebook beforehand and save the results, like it's done in this example notebook:"
    ]


### PR DESCRIPTION
I've reverted #158 because it doesn't work with `nbconvert` version 5.3.

Version 5.4 is blocked, so this should be merged once version 5.5 is available.

Closes #125.