### PR TITLE
 Other way to inject LaTeX preamble 

### DIFF
--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -29,7 +29,7 @@
     "1. Two\n",
     "1. Three\n",
     "\n",
-    "Arbitrary Unicode characters should be supported, e.g. łαßō.\n",
+    "Arbitrary Unicode characters should be supported, e.g. łßō.\n",
     "Note, however, that this only works if your HTML browser and your LaTeX processor provide the appropriate fonts."
    ]
   },

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -1442,13 +1442,6 @@ class GetSizeFromImages(docutils.transforms.Transform):
 
 
 def builder_inited(app):
-    # Add LaTeX definitions to preamble
-    latex_elements = app.builder.config.latex_elements
-    latex_elements['preamble'] = '\n'.join([
-        LATEX_PREAMBLE,
-        latex_elements.get('preamble', ''),
-    ])
-
     # Set default value for CSS prompt width
     if app.config.nbsphinx_prompt_width is None:
         app.config.nbsphinx_prompt_width = {
@@ -1711,6 +1704,13 @@ def setup(app):
             'processClass': 'math',
         }
     })
+
+    # Add LaTeX definitions to preamble
+    latex_elements = app.config._raw_config['latex_elements']
+    latex_elements['preamble'] = '\n'.join([
+        LATEX_PREAMBLE,
+        latex_elements.get('preamble', ''),
+    ])
 
     return {
         'version': __version__,


### PR DESCRIPTION
This didn't work anymore with the latest Sphinx `master`, I think since https://github.com/sphinx-doc/sphinx/commit/848224f6415946122599d531ad49b53544a6e0a2.