### PR TITLE
pandoc: add empty 'c' key

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -1098,7 +1098,7 @@ def markdown2rst(text):
             obj['c'] = [{
                 't': 'Math',
                 'c': [
-                    {'t': 'DisplayMath'},
+                    {'t': 'DisplayMath', 'c': []},
                     # Special marker characters are removed below:
                     '\x0e:nowrap:\x0f\n\n' + obj['c'][1],
                 ]


### PR DESCRIPTION
Older pandoc versions produce an error message in that case:

    pandoc: Error in $[2][0]: key "c" not present