### PR TITLE
Fix Python 2 compat: avoid 'nonlocal' statement

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -1082,15 +1082,14 @@ def markdown2rst(text):
         p.close()
         return p
 
-    open_cite_tag = ''
+    open_cite_tag = ['']
 
     def object_hook(obj):
-        nonlocal open_cite_tag
-        if open_cite_tag:
+        if open_cite_tag[0]:
             if obj.get('t') == 'RawInline' and obj['c'][0] == 'html':
                 p = parse_html(obj)
-                if p.endtag == open_cite_tag:
-                    open_cite_tag = ''
+                if p.endtag == open_cite_tag[0]:
+                    open_cite_tag[0] = ''
             return {'t': 'Str', 'c': ''}  # Object is replaced by empty string
 
         if obj.get('t') == 'RawBlock' and obj['c'][0] == 'latex':
@@ -1109,7 +1108,7 @@ def markdown2rst(text):
         elif obj.get('t') == 'RawInline' and obj['c'][0] == 'html':
             p = parse_html(obj)
             if p.starttag:
-                open_cite_tag = p.starttag
+                open_cite_tag[0] = p.starttag
             if p.cite:
                 obj = {'t': 'RawInline', 'c': ['rst', p.cite]}
         return obj


### PR DESCRIPTION
Python 2 compatibility is broken since 0.4.0 / 46b3664c333d12c895bccadbcd2ceb255f4dff62.

avoid `nonlocal` statement: wrap `open_cite_tag` inside a mutable object.

```
$ python --version
Python 2.7.15+
$ python setup.py build_sphinx
running build_sphinx
Running Sphinx v1.8.3

Exception occurred:
  File "/tmp/nbsphinx.venv/local/lib/python2.7/site-packages/Sphinx-1.8.3-py2.7.egg/sphinx/registry.py", line 472, in load_extension
    mod = __import__(extname, None, None, ['setup'])
  File "/tmp/nbsphinx/src/nbsphinx.py", line 1088
    nonlocal open_cite_tag
                         ^
SyntaxError: invalid syntax
```