### PR TITLE
Re-establish Python 2 compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[bdist_wheel]
+universal=1
+
 [metadata]
 license_file = LICENSE


### PR DESCRIPTION
* remove use of "nonlocal" keyword, see #274
* work around one use of `list.clear()`
* switch back to "universal" wheels, which reverts #268