### PR TITLE
Update template name changed in nbconvert development version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'docutils',
         'jinja2',
-        'nbconvert!=5.4',
+        'nbconvert>=6',
         'traitlets',
         'nbformat',
         'sphinx>=1.8',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         'docutils',
         'jinja2',
-        'nbconvert>=6',
+        'nbconvert!=5.4',
         'traitlets',
         'nbformat',
         'sphinx>=1.8',

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -74,7 +74,7 @@ DISPLAY_DATA_PRIORITY_LATEX = (
 )
 
 RST_TEMPLATE = """
-{% extends 'rst.tpl' %}
+{% extends 'index.rst.j2' %}
 
 {% macro insert_empty_lines(text) %}
 {%- set before, after = text | get_empty_lines %}

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -73,8 +73,10 @@ DISPLAY_DATA_PRIORITY_LATEX = (
     'text/plain',
 )
 
+# The default rst template name is changing in nbconvert 6, so we substitute
+# it in to the *extends* directive.
 RST_TEMPLATE = """
-{% extends 'index.rst.j2' %}
+{% extends '__RST_DEFAULT_TEMPLATE__' %}
 
 {% macro insert_empty_lines(text) %}
 {%- set before, after = text | get_empty_lines %}
@@ -288,7 +290,7 @@ RST_TEMPLATE = """
 {% endif %}
 {{ super() }}
 {% endblock footer %}
-"""
+""".replace('__RST_DEFAULT_TEMPLATE__', nbconvert.RSTExporter().template_file)
 
 
 LATEX_PREAMBLE = r"""


### PR DESCRIPTION
The template name is changing in nbconvert 6 - see https://github.com/jupyter/nbconvert/pull/1056 .

~~I don't know if you want to do a hard change like this, or detect the nbconvert version and switch the name as appropriate. But the change breaks nbconvert building its own docs.~~ - EDIT: it now gets the default template name from nbconvert.