### PR TITLE
Check for ANSI colors in all plain text outputs

### DIFF
--- a/doc/pre-executed.ipynb
+++ b/doc/pre-executed.ipynb
@@ -148,6 +148,50 @@
    "source": [
     "1 / 0"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Client-specific Outputs\n",
+    "\n",
+    "When `nbsphinx` executes notebooks,\n",
+    "it uses the `nbconvert` module to do so.\n",
+    "Certain Jupyter clients might produce output\n",
+    "that differs from what `nbconvert` would produce.\n",
+    "To preserve those original outputs,\n",
+    "the notebook has to be executed and saved\n",
+    "before running Sphinx.\n",
+    "\n",
+    "For example,\n",
+    "the JupyterLab help system shows the help text as cell outputs,\n",
+    "while executing with `nbconvert` doesn't produce any output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0msorted\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0miterable\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m/\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreverse\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "Return a new list containing all items from the iterable in ascending order.\n",
+       "\n",
+       "A custom key function can be supplied to customize the sort order, and the\n",
+       "reverse flag can be set to request the result in descending order.\n",
+       "\u001b[0;31mType:\u001b[0m      builtin_function_or_method\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sorted?"
+   ]
   }
  ],
  "metadata": {
@@ -166,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.5rc1"
   },
   "widgets": {
    "state": {},
@@ -174,5 +218,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
I removed the name "fancy outputs" because now all outputs use the same mechanism.

Fixes #330.

Preview of the added documentation:

* HTML: https://47-210404706-gh.circle-artifacts.com/0/html/pre-executed.html#Client-specific-Outputs
* PDF: https://47-210404706-gh.circle-artifacts.com/0/nbsphinx.pdf#subsubsection.7.1.4

Sadly, there is a problem with LaTeX output:

Page breaks in long code cell outputs with plain text no longer seem to work.
Now there are two nested boxes. Only the outer (framed) box is broken between pages.
If the inner box (created by `sphinxVerbatim`) is longer than a page, I get an error:

    ! TeX capacity exceeded, sorry [input stack size=5000].

@jfbu Do you happen to have an idea how to fix this?