### PR TITLE
Fix css for 'sphinx_copybutton'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 nbsphinx.egg-info/
 .ipynb_checkpoints/
 .python-version
+.vscode
+doc/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,11 @@ matrix:
   - env: SPHINX="==2.2.0"
 
   # a few Python versions using latest Sphinx release
-  - python: "3.4"
-    env: BIBTEX="==0.4.2"
   - python: "3.5"
   - python: "3.6"
   - python: "3.7"
-  - python: "nightly"
-  #- python: "pypy3"
+  - python: "3.8"
+    # - python: "nightly"
 
   - name: Python 2.7 + latest Sphinx
     python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       - python2 -m pip install sphinxcontrib-bibtex==0.4.2
       - python2 -m pip install sphinxcontrib-svg2pdfconverter
       - python2 -m pip install ipywidgets
-      - python2 -m pip install sphinx-copybutton
+      - python2 -m pip install 'sphinx-copybutton<0.2.6'
     script: &py2-script
       - python2 -m nbsphinx
       # We don't execute, because the example notebooks use Python 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ matrix:
   - python: "3.5"
   - python: "3.6"
   - python: "3.7"
-  - python: "3.8"
-    # - python: "nightly"
+  - python: "nightly"
+  # - python: "pypy3"
 
   - name: Python 2.7 + latest Sphinx
     python: "2.7"
@@ -52,6 +52,9 @@ matrix:
           - python2
     install: *py2-install
     script: *py2-script
+
+  allow_failures:
+    - python: "nightly"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ matrix:
       - python2 -m pip install sphinxcontrib-bibtex==0.4.2
       - python2 -m pip install sphinxcontrib-svg2pdfconverter
       - python2 -m pip install ipywidgets
+      - python2 -m pip install sphinx-copybutton
     script: &py2-script
       - python2 -m nbsphinx
       # We don't execute, because the example notebooks use Python 3

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -7,7 +7,7 @@
 extensions = [
     'nbsphinx',
     'sphinx_copybutton',
-    'sphinx.ext.mathjax',  # for math equation
+    'sphinx.ext.mathjax',  # for math equations
     'sphinxcontrib.bibtex',  # for bibliographic references
     'sphinxcontrib.rsvgconverter',  # for SVG->PDF conversion in LaTeX output
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -6,7 +6,8 @@
 # Select nbsphinx and, if needed, other Sphinx extensions:
 extensions = [
     'nbsphinx',
-    'sphinx.ext.mathjax',  # for math equations
+    'sphinx_copybutton',
+    'sphinx.ext.mathjax',  # for math equation
     'sphinxcontrib.bibtex',  # for bibliographic references
     'sphinxcontrib.rsvgconverter',  # for SVG->PDF conversion in LaTeX output
 ]

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,3 +5,4 @@ pandas
 sphinxcontrib-bibtex
 sphinxcontrib-svg2pdfconverter
 ipywidgets
+sphinx-copybutton

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -621,6 +621,7 @@ div.nboutput.container div.output_area > img{
 }
 
 div.nboutput.container div.output_area > div[class*=highlight],
+div.nboutput.container div.output_area.rendered_html > img{
     padding: 0;
 }
 

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -178,7 +178,7 @@ RST_TEMPLATE = """
 
     .. raw:: html
 
-        <div class="js-render-output"></div>
+        <div class="output_javascript"></div>
         <script type="text/javascript">
         var element = document.currentScript.previousSibling.previousSibling;
 {{ output.data['application/javascript'] | indent | indent }}
@@ -615,7 +615,7 @@ div.nbinput.container div.input_area div[class*=highlight] > pre,
 div.nboutput.container div.output_area div[class*=highlight] > pre,
 div.nboutput.container div.output_area div[class*=highlight].math,
 div.nboutput.container div.output_area.rendered_html,
-div.nboutput.container div.output_area > div.js-render-output,
+div.nboutput.container div.output_area > div.output_javascript,
 div.nboutput.container div.output_area > img{
     padding: 0.4rem;
 }

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -611,7 +611,6 @@ div.rendered_html tbody tr:hover {
   background: rgba(66, 165, 245, 0.2);
 }
 
-/* set the padding for the pre so copybtn icon won't cause an overflow */
 div.nbinput.container > div.input_area > div[class*=highlight] > pre,
 div.nboutput.container > div.output_area > div[class*=highlight] > pre,
 div.nboutput.container > div.output_area > div[class*=highlight].math,

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -636,11 +636,6 @@ CSS_STRING_READTHEDOCS = """
     margin-bottom: 19px;  /* padding has already 5px */
 }
 
-/* fix copybtn icon positioning (needed for 'sphinx_copybutton') */
-a.copybtn > img{
-    vertical-align: top;
-}
-
 /* ... except between code cells! */
 .nblast.container + .nbinput.container {
     margin-top: -19px;

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -479,8 +479,8 @@ div.nboutput.container div.prompt pre {
 div.nbinput.container div.prompt,
 div.nboutput.container div.prompt {
     min-width: %(nbsphinx_prompt_width)s;
-    padding-top: 0.4em;
-    padding-right: 0.4em;
+    padding-top: 0.3rem;
+    padding-right: 0.3rem;
     text-align: right;
     flex: 0;
 }

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -587,10 +587,6 @@ div.nboutput.container div.output_area:not(.rendered_html) > img{
     padding: 0.4rem;
 }
 
-div.nboutput.container div.output_area > div[class*=highlight]{
-    padding: 0;
-}
-
 /* hide copybtn icon on prompts (needed for 'sphinx_copybutton') */
 .prompt a.copybtn {
     display: none;

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -625,7 +625,7 @@ div.nboutput.container div.output_area.rendered_html > img{
     padding: 0;
 }
 
-/* fix positioning of copybtn icon */
+/* fix positioning of copybtn icon from 'sphinx_copybutton' */
 a.copybtn {
     padding: 0;
     top: 0.1em;
@@ -634,7 +634,7 @@ a.copybtn > img{
     padding: 0;
 }
 
-/* hide copybtn icon on prompts */
+/* hide copybtn icon on prompts from 'sphinx_copybutton' */
 .prompt.highlight-none.notranslate a.copybtn {
     display: none;
 }
@@ -650,10 +650,14 @@ CSS_STRING_READTHEDOCS = """
     margin-bottom: 19px;  /* padding has already 5px */
 }
 
-/* fix copybtn overflow problem */
+/* fix copybtn from overflow problem 'sphinx_copybutton' */
 div.nbinput.container div.input_area > div[class^='highlight'],
 div.nboutput.container div.output_area > div[class^='highlight']{
     overflow-y: hidden;
+}
+/* fix copybtn icon positioning from 'sphinx_copybutton' */
+a.copybtn > img{
+    vertical-align: top;
 }
 
 /* ... except between code cells! */

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -584,7 +584,7 @@ div.nboutput.container div.output_area div[class*=highlight].math,
 div.nboutput.container div.output_area.rendered_html,
 div.nboutput.container div.output_area > div.output_javascript,
 div.nboutput.container div.output_area:not(.rendered_html) > img{
-    padding: 0.4rem;
+    padding: 0.3rem;
 }
 
 /* hide copybtn icon on prompts (needed for 'sphinx_copybutton') */

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -577,6 +577,25 @@ div.nboutput.container div.output_area.stderr {
 .ansi-bold { font-weight: bold; }
 .ansi-underline { text-decoration: underline; }
 
+
+div.nbinput.container div.input_area div[class*=highlight] > pre,
+div.nboutput.container div.output_area div[class*=highlight] > pre,
+div.nboutput.container div.output_area div[class*=highlight].math,
+div.nboutput.container div.output_area.rendered_html,
+div.nboutput.container div.output_area > div.output_javascript,
+div.nboutput.container div.output_area:not(.rendered_html) > img{
+    padding: 0.4rem;
+}
+
+div.nboutput.container div.output_area > div[class*=highlight]{
+    padding: 0;
+}
+
+/* hide copybtn icon on prompts from 'sphinx_copybutton' */
+.prompt a.copybtn {
+    display: none;
+}
+
 /* Some additional styling taken form the Jupyter notebook CSS */
 div.rendered_html table {
   border: none;
@@ -610,25 +629,6 @@ div.rendered_html tbody tr:nth-child(odd) {
 div.rendered_html tbody tr:hover {
   background: rgba(66, 165, 245, 0.2);
 }
-
-div.nbinput.container div.input_area div[class*=highlight] > pre,
-div.nboutput.container div.output_area div[class*=highlight] > pre,
-div.nboutput.container div.output_area div[class*=highlight].math,
-div.nboutput.container div.output_area.rendered_html,
-div.nboutput.container div.output_area > div.output_javascript,
-div.nboutput.container div.output_area:not(.rendered_html) > img{
-    padding: 0.4rem;
-}
-
-div.nboutput.container div.output_area > div[class*=highlight]{
-    padding: 0;
-}
-
-/* hide copybtn icon on prompts from 'sphinx_copybutton' */
-.prompt a.copybtn {
-    display: none;
-}
-
 """
 
 CSS_STRING_READTHEDOCS = """

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -617,7 +617,7 @@ div.nboutput.container > div.output_area > div[class*=highlight].math,
 div.nboutput.container > div.output_area.rendered_html,
 div.nboutput.container > div.output_area > div,
 div.nboutput.container > div.output_area > img{
-    padding: 0.4em;
+    padding: 0.4rem;
 }
 
 div.nboutput.container > div.output_area > div[class*=highlight]{

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -614,11 +614,20 @@ div.rendered_html tbody tr:hover {
 /* set the padding for the pre so copybtn icon won't cause an overflow */
 div.nbinput.container > div.input_area > div[class*=highlight] > pre,
 div.nboutput.container > div.output_area > div[class*=highlight] > pre,
+div.nboutput.container > div.output_area > div[class*=highlight].math,
 div.nboutput.container > div.output_area.rendered_html,
-div.nboutput.container > div.output_area > div.widget-subarea,
-div.nboutput.container > div.output_area > div.math,
+div.nboutput.container > div.output_area > div,
 div.nboutput.container > div.output_area > img{
     padding: 0.4em;
+}
+
+div.nboutput.container > div.output_area > div[class*=highlight]{
+    padding: 0;
+}
+
+div.nboutput.container > div.output_area > div.admonition{
+    margin: calc(20px + 0.4em) 0.4em;
+    padding: 10px 30px;
 }
 
 /* fix positioning of copybtn icon */

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -625,11 +625,6 @@ div.nboutput.container div.output_area.rendered_html > img{
     padding: 0;
 }
 
-div.nboutput.container > div.output_area > div.admonition{
-    margin: calc(20px + 0.4em) 0.4em;
-    padding: 10px 30px;
-}
-
 /* fix positioning of copybtn icon */
 a.copybtn {
     padding: 0;

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -611,16 +611,16 @@ div.rendered_html tbody tr:hover {
   background: rgba(66, 165, 245, 0.2);
 }
 
-div.nbinput.container > div.input_area > div[class*=highlight] > pre,
-div.nboutput.container > div.output_area > div[class*=highlight] > pre,
-div.nboutput.container > div.output_area > div[class*=highlight].math,
-div.nboutput.container > div.output_area.rendered_html,
+div.nbinput.container div.input_area div[class*=highlight] > pre,
+div.nboutput.container div.output_area div[class*=highlight] > pre,
+div.nboutput.container div.output_area div[class*=highlight].math,
+div.nboutput.container div.output_area.rendered_html,
 div.nboutput.container div.output_area > div.js-render-output,
-div.nboutput.container > div.output_area > img{
+div.nboutput.container div.output_area > img{
     padding: 0.4rem;
 }
 
-div.nboutput.container > div.output_area > div[class*=highlight]{
+div.nboutput.container div.output_area > div[class*=highlight],
     padding: 0;
 }
 

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -178,7 +178,7 @@ RST_TEMPLATE = """
 
     .. raw:: html
 
-        <div></div>
+        <div class="js-render-output"></div>
         <script type="text/javascript">
         var element = document.currentScript.previousSibling.previousSibling;
 {{ output.data['application/javascript'] | indent | indent }}
@@ -615,7 +615,7 @@ div.nbinput.container > div.input_area > div[class*=highlight] > pre,
 div.nboutput.container > div.output_area > div[class*=highlight] > pre,
 div.nboutput.container > div.output_area > div[class*=highlight].math,
 div.nboutput.container > div.output_area.rendered_html,
-div.nboutput.container > div.output_area > div,
+div.nboutput.container div.output_area > div.js-render-output,
 div.nboutput.container > div.output_area > img{
     padding: 0.4rem;
 }

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -640,11 +640,6 @@ CSS_STRING_READTHEDOCS = """
     margin-bottom: 19px;  /* padding has already 5px */
 }
 
-/* fix copybtn overflow problem (needed for 'sphinx_copybutton') */
-div.nbinput.container div.input_area > div[class^='highlight'],
-div.nboutput.container div.output_area > div[class^='highlight']{
-    overflow-y: hidden;
-}
 /* fix copybtn icon positioning (needed for 'sphinx_copybutton') */
 a.copybtn > img{
     vertical-align: top;

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -504,7 +504,6 @@ div.nboutput.container div.prompt pre {
 /* input/output area */
 div.nbinput.container div.input_area,
 div.nboutput.container div.output_area {
-    padding: 0.4em;
     -webkit-flex: 1;
     flex: 1;
     overflow: auto;
@@ -611,6 +610,28 @@ div.rendered_html tbody tr:nth-child(odd) {
 div.rendered_html tbody tr:hover {
   background: rgba(66, 165, 245, 0.2);
 }
+
+/* set the padding for the pre so copybtn icon won't cause an overflow */
+div.nbinput.container div.input_area div[class*=highlight] pre,
+div.nboutput.container div.output_area div[class*=highlight] pre,
+div.nboutput.container div.output_area.rendered_html,
+div.nboutput.container div.output_area div.widget-subarea,
+div.nboutput.container div.output_area div.math,
+div.nboutput.container div.output_area > img{
+    padding: 0.4em;
+}
+
+/* fix positioning of copybtn icon */
+a.copybtn {
+    padding: 0;
+    top: 0.1em;
+}
+
+/* hide copybtn icon on prompts */
+.prompt.highlight-none.notranslate a.copybtn {
+    display: none;
+}
+
 """
 
 CSS_STRING_READTHEDOCS = """

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -591,7 +591,7 @@ div.nboutput.container div.output_area > div[class*=highlight]{
     padding: 0;
 }
 
-/* hide copybtn icon on prompts from 'sphinx_copybutton' */
+/* hide copybtn icon on prompts (needed for 'sphinx_copybutton') */
 .prompt a.copybtn {
     display: none;
 }
@@ -640,12 +640,12 @@ CSS_STRING_READTHEDOCS = """
     margin-bottom: 19px;  /* padding has already 5px */
 }
 
-/* fix copybtn from overflow problem 'sphinx_copybutton' */
+/* fix copybtn overflow problem (needed for 'sphinx_copybutton') */
 div.nbinput.container div.input_area > div[class^='highlight'],
 div.nboutput.container div.output_area > div[class^='highlight']{
     overflow-y: hidden;
 }
-/* fix copybtn icon positioning from 'sphinx_copybutton' */
+/* fix copybtn icon positioning (needed for 'sphinx_copybutton') */
 a.copybtn > img{
     vertical-align: top;
 }

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -650,6 +650,12 @@ CSS_STRING_READTHEDOCS = """
     margin-bottom: 19px;  /* padding has already 5px */
 }
 
+/* fix copybtn overflow problem */
+div.nbinput.container div.input_area > div[class^='highlight'],
+div.nboutput.container div.output_area > div[class^='highlight']{
+    overflow-y: hidden;
+}
+
 /* ... except between code cells! */
 .nblast.container + .nbinput.container {
     margin-top: -19px;

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -587,6 +587,12 @@ div.nboutput.container div.output_area:not(.rendered_html) > img{
     padding: 0.3rem;
 }
 
+/* fix copybtn overflow problem in chromium (needed for 'sphinx_copybutton') */
+div.nbinput.container div.input_area > div[class^='highlight'],
+div.nboutput.container div.output_area > div[class^='highlight']{
+    overflow-y: hidden;
+}
+
 /* hide copybtn icon on prompts (needed for 'sphinx_copybutton') */
 .prompt a.copybtn {
     display: none;
@@ -653,12 +659,6 @@ CSS_STRING_READTHEDOCS = """
 
 CSS_STRING_CLOUD = """
 /* CSS overrides for cloud theme */
-
-/* fix copybtn overflow problem (needed for 'sphinx_copybutton') */
-div.nbinput.container div.input_area > div[class^='highlight'],
-div.nboutput.container div.output_area > div[class^='highlight']{
-    overflow-y: hidden;
-}
 
 /* nicer titles and more space for info and warning logos */
 

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -630,6 +630,9 @@ a.copybtn {
     padding: 0;
     top: 0.1em;
 }
+a.copybtn > img{
+    padding: 0;
+}
 
 /* hide copybtn icon on prompts */
 .prompt.highlight-none.notranslate a.copybtn {

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -616,21 +616,11 @@ div.nboutput.container div.output_area div[class*=highlight] > pre,
 div.nboutput.container div.output_area div[class*=highlight].math,
 div.nboutput.container div.output_area.rendered_html,
 div.nboutput.container div.output_area > div.output_javascript,
-div.nboutput.container div.output_area > img{
+div.nboutput.container div.output_area:not(.rendered_html) > img{
     padding: 0.4rem;
 }
 
-div.nboutput.container div.output_area > div[class*=highlight],
-div.nboutput.container div.output_area.rendered_html > img{
-    padding: 0;
-}
-
-/* fix positioning of copybtn icon from 'sphinx_copybutton' */
-a.copybtn {
-    padding: 0;
-    top: 0.1em;
-}
-a.copybtn > img{
+div.nboutput.container div.output_area > div[class*=highlight]{
     padding: 0;
 }
 

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -635,7 +635,7 @@ a.copybtn > img{
 }
 
 /* hide copybtn icon on prompts from 'sphinx_copybutton' */
-.prompt.highlight-none.notranslate a.copybtn {
+.prompt a.copybtn {
     display: none;
 }
 

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -654,6 +654,12 @@ CSS_STRING_READTHEDOCS = """
 CSS_STRING_CLOUD = """
 /* CSS overrides for cloud theme */
 
+/* fix copybtn overflow problem (needed for 'sphinx_copybutton') */
+div.nbinput.container div.input_area > div[class^='highlight'],
+div.nboutput.container div.output_area > div[class^='highlight']{
+    overflow-y: hidden;
+}
+
 /* nicer titles and more space for info and warning logos */
 
 div.admonition p.admonition-title {

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -612,12 +612,12 @@ div.rendered_html tbody tr:hover {
 }
 
 /* set the padding for the pre so copybtn icon won't cause an overflow */
-div.nbinput.container div.input_area div[class*=highlight] pre,
-div.nboutput.container div.output_area div[class*=highlight] pre,
-div.nboutput.container div.output_area.rendered_html,
-div.nboutput.container div.output_area div.widget-subarea,
-div.nboutput.container div.output_area div.math,
-div.nboutput.container div.output_area > img{
+div.nbinput.container > div.input_area > div[class*=highlight] > pre,
+div.nboutput.container > div.output_area > div[class*=highlight] > pre,
+div.nboutput.container > div.output_area.rendered_html,
+div.nboutput.container > div.output_area > div.widget-subarea,
+div.nboutput.container > div.output_area > div.math,
+div.nboutput.container > div.output_area > img{
     padding: 0.4em;
 }
 


### PR DESCRIPTION
Changed CSS so 'sphinx_copybutton' will look properly out of the box.
- Moved `padding: 0.4em;` from `.input_area, .output_area` to its child `pre`
- Added `padding: 0.4em;` to other `.input_area, .output_area` child elements, to keep the styling consistent
- Added `sphinx_copybutton` to the docs
- Tested output for `alabaster` and `sphinx_rtd_theme`

**Before:**
![copybtn_before](https://user-images.githubusercontent.com/9513634/68527826-aeb6b100-02eb-11ea-98b0-823a02261f8f.jpg)

**After:**
![copybtn_after](https://user-images.githubusercontent.com/9513634/68527829-b1b1a180-02eb-11ea-94ef-3feb5298e4eb.jpg)

**After sphinx_rtd_theme:**
![copybtn_after_rtd](https://user-images.githubusercontent.com/9513634/68527830-b4ac9200-02eb-11ea-89e4-1054ab54ac9f.jpg)

closes #333 