### PR TITLE
Use PyPi version of sphinx-material

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/bashtage/sphinx-material.git
+sphinx-material
 ipykernel
 numpy
 matplotlib


### PR DESCRIPTION
`sphinx-material` has a [release on PyPi](https://pypi.org/project/sphinx-material/) now, no need to install it from the repo anymore.