### PR TITLE
Save executed notebooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   - name: default Python + latest Sphinx
 
   # a few older Sphinx releases using default Python version
-  - env: SPHINX="==1.8.0" BIBTEX="==0.4.2"
+  - env: SPHINX="==1.8.1" BIBTEX="==0.4.2"
   - env: SPHINX="==1.8.5" BIBTEX="==0.4.2"
   - env: SPHINX="==2.0.0"
   - env: SPHINX="==2.1.0"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,19 +39,31 @@ os.environ['MY_DUMMY_VARIABLE'] = 'Hello from conf.py!'
 nbsphinx_prolog = r"""
 {% set docname = 'doc/' + env.doc2path(env.docname, base=None) %}
 
-.. only:: html
+.. raw:: html
 
-    .. role:: raw-html(raw)
-        :format: html
-
-    .. nbinfo::
-
-        This page was generated from `{{ docname }}`__.
+    <div class="admonition note">
+      <p>This page was generated from
+        <a class="reference external" href="https://github.com/spatialaudio/nbsphinx/blob/{{ env.config.release|e }}/{{ docname|e }}">{{ docname|e }}</a>.
         Interactive online version:
-        :raw-html:`<a href="https://mybinder.org/v2/gh/spatialaudio/nbsphinx/{{ env.config.release }}?filepath={{ docname }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>`
-
-    __ https://github.com/spatialaudio/nbsphinx/blob/
-        {{ env.config.release }}/{{ docname }}
+        <a href="https://mybinder.org/v2/gh/spatialaudio/nbsphinx/{{ env.config.release|e }}?filepath={{ docname|e }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.
+        <a class="reference external" href="{{ env.docname|basename|e }}.ipynb">Download notebook file</a>.
+      </p>
+      <script>
+        if (document.location.host) {
+          var p = document.currentScript.previousSibling.previousSibling;
+          var a = document.createElement('a');
+          a.innerHTML = 'View in <em>nbviewer</em>';
+          a.href = `https://nbviewer.jupyter.org/url${
+            (window.location.protocol == 'https:' ? 's/' : '/') +
+            window.location.host +
+            window.location.pathname.slice(0, -4) }ipynb`;
+          a.classList.add('reference');
+          a.classList.add('external');
+          p.appendChild(a);
+          p.appendChild(document.createTextNode('.'));
+        }
+      </script>
+    </div>
 
 .. raw:: latex
 


### PR DESCRIPTION
This provides a downloadable copy of the *executed* notebooks.

As a usage example, links to the executed notebooks are added to the docs (in addition to the links to the source files on Github). While the source files on Github are typically "clean" (i.e. without outputs), those new notebook files contain outputs (unless execution was manually disabled).

A possible use case of this is together with `nbsphinx_custom_formats`, where notebook links can be provided even if the original sources don't contain notebooks (but `*.py`/`*.Rmd`/...).

As a further usage example, links to `nbviewer` are provided, which contain the code cell outputs.
Those links point `nbviewer` back to wherever the HTML files are hosted. It is not necessary to commit executed notebooks for that.

Rendered example:
https://101-210404706-gh.circle-artifacts.com/0/html/code-cells.html, which contains links to:

* (un-executed) source file on Github: https://github.com/spatialaudio/nbsphinx/blob/0.4.2-79-g39fe2dc/doc/code-cells.ipynb
* Executed notebook file: https://101-210404706-gh.circle-artifacts.com/0/html/code-cells.ipynb
* nbviewer: https://nbviewer.jupyter.org/urls/101-210404706-gh.circle-artifacts.com/0/html/code-cells.ipynb