### PR TITLE
DOC: Remove "Download notebook file" link

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,7 +46,6 @@ nbsphinx_prolog = r"""
         <a class="reference external" href="https://github.com/spatialaudio/nbsphinx/blob/{{ env.config.release|e }}/{{ docname|e }}">{{ docname|e }}</a>.
         Interactive online version:
         <a href="https://mybinder.org/v2/gh/spatialaudio/nbsphinx/{{ env.config.release|e }}?filepath={{ docname|e }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.
-        <a class="reference external" href="{{ env.docname|basename|e }}.ipynb">Download notebook file</a>.
       </p>
       <script>
         if (document.location.host) {


### PR DESCRIPTION
... because notebooks may depend on local files that are not downloaded.

Users can still choose to do this, if they like.