### PR TITLE
support nbsphinx on Read the Doc #184

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,3 +6,4 @@ sphinxcontrib-bibtex
 sphinxcontrib-svg2pdfconverter
 ipywidgets
 sphinx-copybutton
+nbsphinx


### PR DESCRIPTION
nbspinx is not in "./doc", leading into the problem in #184.