### PR TITLE
Use CSS fixes for RTD theme also for dask theme

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -1637,7 +1637,11 @@ def html_page_context(app, pagename, templatename, context, doctree):
     style = ''
     if doctree and doctree.get('nbsphinx_include_css'):
         style += CSS_STRING % app.config
-    if doctree and app.config.html_theme in ('sphinx_rtd_theme', 'julia'):
+    if doctree and app.config.html_theme in (
+            'sphinx_rtd_theme',
+            'julia',
+            'dask_sphinx_theme',
+            ):
         style += CSS_STRING_READTHEDOCS
     if doctree and app.config.html_theme.endswith('cloud'):
         style += CSS_STRING_CLOUD
@@ -1799,7 +1803,7 @@ def visit_admonition_html(self, node):
     if len(node.children) >= 2:
         node[0]['classes'].append('admonition-title')
         html_theme = self.settings.env.config.html_theme
-        if html_theme in ('sphinx_rtd_theme', 'julia'):
+        if html_theme in ('sphinx_rtd_theme', 'julia', 'dask_sphinx_theme'):
             node.children[0]['classes'].extend(['fa', 'fa-exclamation-circle'])
 
 


### PR DESCRIPTION
The dask theme (https://github.com/dask/dask-sphinx-theme) is based on the RTD theme, so I guess it makes sense to apply the same CSS fixes.