### PR TITLE
[WIP] allow toggling inputs and outputs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,6 +13,7 @@ extensions = [
     'sphinxcontrib.bibtex',  # for bibliographic references
     'sphinxcontrib.rsvgconverter',  # for SVG->PDF conversion in LaTeX output
     'sphinx_gallery.load_style',  # load CSS for gallery (needs SG >= 0.6)
+    'sphinx_togglebutton',
 ]
 
 # Default language for syntax highlighting in reST and Markdown cells:

--- a/doc/hidden-cells.ipynb
+++ b/doc/hidden-cells.ipynb
@@ -79,6 +79,62 @@
    "source": [
     "This is the cell after the hidden cell."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Toggling Cells\n",
+    "\n",
+    "You can make a cell toggle-able by adding \"hide_input\" to the cell metadata tags\n",
+    "\n",
+    "TODO: check how adding a tag is explained in other parts of doc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "tags": [
+     "toggle_input"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "15"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1 + 14"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "tags": [
+     "hide_output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "my output is hidden\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"my output is hidden\")"
+   ]
   }
  ],
  "metadata": {
@@ -97,9 +153,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/doc/hidden-cells.ipynb
+++ b/doc/hidden-cells.ipynb
@@ -93,31 +93,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "metadata": {
     "tags": [
      "toggle_input"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "15"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "1 + 14"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "metadata": {
     "tags": [
      "hide_output"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -7,4 +7,5 @@ sphinxcontrib-svg2pdfconverter
 ipywidgets
 sphinx-copybutton
 sphinx-gallery
+sphinx-togglebutton
 jupytext

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -115,6 +115,9 @@ RST_TEMPLATE = """
 {%- if not cell.outputs %}
     :no-output:
 {%- endif %}
+{%- if 'toggle_input' in cell.metadata.tags %}
+    :class: toggle
+{%- endif %}
 
 {{ cell.source.strip('\n') | indent }}
 {% endblock input %}
@@ -1045,6 +1048,7 @@ def _create_code_nodes(directive):
         outer_classes = ['nbinput']
         if 'no-output' in directive.options:
             outer_classes.append('nblast')
+        outer_classes.append(directive.options.get('class', ''))
         inner_classes = ['input_area']
         prompt_template = config.nbsphinx_input_prompt
         if not execution_count:
@@ -1122,6 +1126,7 @@ class NbInput(rst.Directive):
         'empty-lines-before': rst.directives.nonnegative_int,
         'empty-lines-after': rst.directives.nonnegative_int,
         'no-output': rst.directives.flag,
+        'class': rst.directives.unchanged,
     }
     has_content = True
 


### PR DESCRIPTION
This (WIP) PR addresses #303. 

I took a quick look over nbsphinx, and wanted to highlight some challenges and decisions involved.  (I'll clean up / flesh out the doc notebook before wrapping up).

### Changes

* NbOutput directive accepts :class: option, puts it on **outer classes**
* template checks for "hide_input" tag, if found adds the "toggle" class.
* sphinx-toggle added to extensions

### Example

Hidden:

![image](https://user-images.githubusercontent.com/2574498/79388842-1082e300-7f3c-11ea-9484-8166ed808e99.png)

Toggled:

![image](https://user-images.githubusercontent.com/2574498/79388872-1d073b80-7f3c-11ea-8f5c-843288e84918.png)


### Questions

* the toggle class has to be set on the outer container. Right now I use the :class: option, but NbInput uses that option for the inner container. Is it worth adding a toggle option to the NbOutput and NbInput directives?
* does using the metadata.tags "toggle_input" and "toggle_output" sound good?
* other things to look out for?