### PR TITLE
Parse <img> tags

### DIFF
--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -246,8 +246,39 @@
     "\n",
     "Remote image: ![Python logo (remote)](https://www.python.org/static/img/python-logo-large.png)\n",
     "\n",
-    "    ![Python logo (remote)](https://www.python.org/static/img/python-logo-large.png)\n",
+    "    ![Python logo (remote)](https://www.python.org/static/img/python-logo-large.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using the HTML `<img>` tag\n",
     "\n",
+    "The aforementioned Markdown syntax for including images\n",
+    "doesn't allow specifying the image size.\n",
+    "\n",
+    "If you want to control the size of the included image,\n",
+    "you can use the HTML\n",
+    "[\\<img\\>](https://www.w3.org/TR/html52/semantics-embedded-content.html#the-img-element)\n",
+    "element with the `width` attribute like this:\n",
+    "\n",
+    "```html\n",
+    "<img src=\"images/notebook_icon.png\" alt=\"Jupyter notebook icon\" width=\"300\">\n",
+    "```\n",
+    "\n",
+    "<img src=\"images/notebook_icon.png\" alt=\"Jupyter notebook icon\" width=\"300\">\n",
+    "\n",
+    "In addition to the `src`, `alt`, `width` and `height` attributes,\n",
+    "you can also use the `class` attribute,\n",
+    "which is simply forwarded to the HTML output (and ignored in LaTeX output).\n",
+    "All other attributes are ignored."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### SVG support for LaTeX\n",
     "\n",
     "LaTeX doesn't support SVG images, but there are Sphinx extensions that can be used for automatically converting SVG images for inclusion in LaTeX output.\n",
@@ -443,8 +474,7 @@
     "\n",
     "```\n",
     "[beginning of this section](#Links-to-Other-Notebooks)\n",
-    "```",
-    "\n",
+    "```\n",
     "It's also possible to create a\n",
     "[link to the beginning of the current page](#),\n",
     "by simply using a `#` character:\n",


### PR DESCRIPTION
Sadly, with the current Pandoc-based implementation I couldn't make the `align` attribute work. I had to use "inline" images (because Pandoc stores the `<img>` tag in a `RawInline` object), but `:align:` is not supported in reST for inline images.

This fixes (at least partially) #52, #284, #437 and probably #321.

Rendered HTML: https://208-210404706-gh.circle-artifacts.com/0/html/markdown-cells.html#Using-the-HTML-%3Cimg%3E-tag

Rendered PDF: https://208-210404706-gh.circle-artifacts.com/0/nbsphinx.pdf#subsubsection.3.5.1

And rendered HTML on RTD: https://nbsphinx--438.org.readthedocs.build/en/438/markdown-cells.html#Using-the-HTML-%3Cimg%3E-tag