### PR TITLE
DOC: Remove <p> from nbsphinx_prolog

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,11 +46,11 @@ nbsphinx_prolog = r"""
 .. raw:: html
 
     <div class="admonition note">
-      <p>This page was generated from
-        <a class="reference external" href="https://github.com/spatialaudio/nbsphinx/blob/{{ env.config.release|e }}/{{ docname|e }}">{{ docname|e }}</a>.
-        Interactive online version:
-        <a href="https://mybinder.org/v2/gh/spatialaudio/nbsphinx/{{ env.config.release|e }}?filepath={{ docname|e }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.
-      </p>
+      This page was generated from
+      <a class="reference external" href="https://github.com/spatialaudio/nbsphinx/blob/{{ env.config.release|e }}/{{ docname|e }}">{{ docname|e }}</a>.
+      Interactive online version:
+      <a href="https://mybinder.org/v2/gh/spatialaudio/nbsphinx/{{ env.config.release|e }}?filepath={{ docname|e }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>.
+      
       <script>
         if (document.location.host) {
           var p = document.currentScript.previousSibling.previousSibling;


### PR DESCRIPTION
This seems to work better on multiple themes.

Alabaster theme: https://235-210404706-gh.circle-artifacts.com/0/html/prolog-and-epilog.html