### PR TITLE
Use px padding to avoid Safari img-too-large scrolling

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -605,7 +605,7 @@ div.nboutput.container div.output_area div[class*=highlight].math,
 div.nboutput.container div.output_area.rendered_html,
 div.nboutput.container div.output_area > div.output_javascript,
 div.nboutput.container div.output_area:not(.rendered_html) > img{
-    padding: 0.3rem;
+    padding: 5px;
 }
 
 /* fix copybtn overflow problem in chromium (needed for 'sphinx_copybutton') */


### PR DESCRIPTION
The rem padding causes `<img>` image elements to have fractional heights, like
137.59375px for the [7] image in
<https://nbsphinx.readthedocs.io/en/0.6.1/code-cells.html#Local-Image-Files>. In
Safari (and only Safari), this means that the "layout" height (`.clientHeight`)
of the `img` tag being 138px, while the height of the surrounding `div` is
137px. The slightly overlap means that the image scrolls slightly, causing
unsightly and disconcerting scroll bars to appear, and making scrolling "jerky"
as the mouse gets captured briefly.

AIUI, the behaviour of sub-pixel round isn't specified as part of CSS, and there
being behaviour differences isn't necessarily unexpected.

(This seems to only apply to Safari, other browsers like Chrome and Firefox have
both the `img` and `div` have height 138px.)

Fixes: #452