### PR TITLE
linkcheck: ignore Github diff links

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -101,7 +101,10 @@ project = 'nbsphinx'
 author = 'Matthias Geier'
 copyright = '2020, ' + author
 
-linkcheck_ignore = [r'http://localhost:\d+/']
+linkcheck_ignore = [
+    r'http://localhost:\d+/',
+    'https://github.com/spatialaudio/nbsphinx/compare/',
+]
 
 # -- Get version information and date from Git ----------------------------
 


### PR DESCRIPTION
... because checking them on CircleCI led to the error "429 Client Error: too many requests".