### PR TITLE
Use no-scaled-link class for code output images (e.g. plots)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,9 +22,6 @@ highlight_language = 'none'
 # Don't add .txt suffix to source files:
 html_sourcelink_suffix = ''
 
-# Work-around until https://github.com/sphinx-doc/sphinx/issues/4229 is solved:
-html_scaled_image_link = False
-
 # List of arguments to be passed to the kernel that executes the notebooks:
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",

--- a/doc/usage.ipynb
+++ b/doc/usage.ipynb
@@ -152,20 +152,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### `html_scaled_image_link`\n",
-    "\n",
-    "As a work-around -- until https://github.com/sphinx-doc/sphinx/issues/4229 is solved --\n",
-    "you should set [html_scaled_image_link](http://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_scaled_image_link) to `False`:\n",
-    "\n",
-    "```python\n",
-    "html_scaled_image_link = False\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "#### `html_sourcelink_suffix`\n",
     "\n",
     "\n",

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -157,6 +157,7 @@ RST_TEMPLATE = """
 
     .. image:: {{ output.metadata.filenames[datatype] | posix_path }}
 {%- if datatype in output.metadata %}
+        :class: no-scaled-link
 {%- set width = output.metadata[datatype].width %}
 {%- if width %}
         :width: {{ width }}

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -1267,14 +1267,19 @@ class ImgParser(html.parser.HTMLParser):
         img_path = nbconvert.filters.posix_path(attrs['src'])
         lines = ['image:: ' + img_path]
         indent = ' ' * 4
+        classes = []
         if 'class' in attrs:
-            lines.append(indent + ':class: ' + attrs['class'])
+            classes.append(attrs['class'])
         if 'alt' in attrs:
             lines.append(indent + ':alt: ' + attrs['alt'])
         if 'width' in attrs:
             lines.append(indent + ':width: ' + attrs['width'])
         if 'height' in attrs:
             lines.append(indent + ':height: ' + attrs['height'])
+        if {'width', 'height'}.intersection(attrs):
+            classes.append('no-scaled-link')
+        if classes:
+            lines.append(indent + ':class: ' + ' '.join(classes))
 
         definition = '\n'.join(lines)
         hex_id = uuid.uuid4().hex


### PR DESCRIPTION
This is available since Sphinx 3.0.0 and it
makes the use of `html_scaled_image_link` obsolete.

Closes #232.

See https://github.com/sphinx-doc/sphinx/issues/4229.