### PR TITLE
Don't override Pygments background color in code cells

### DIFF
--- a/doc/usage.ipynb
+++ b/doc/usage.ipynb
@@ -196,6 +196,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### `pygments_style`\n",
+    "\n",
+    "Use\n",
+    "[pygments_style](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-pygments_style)\n",
+    "to change the color/font theme that's used for syntax highlighting in source code.\n",
+    "\n",
+    "This affects both [code cells](code-cells.ipynb)\n",
+    "and [code blocks in Markdown cells](markdown-cells.ipynb#Code)\n",
+    "(unless overwritten by the\n",
+    "[html_theme](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_theme))."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### `suppress_warnings`\n",
     "\n",
     "Warnings can be really helpful to detect small mistakes,\n",
@@ -886,7 +902,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -426,21 +426,30 @@ CSS_STRING = """
 /* CSS for nbsphinx extension */
 
 /* remove conflicting styling from Sphinx themes */
-div.nbinput.container,
-div.nbinput.container div.prompt,
-div.nbinput.container div.input_area,
-div.nbinput.container div[class*=highlight],
-div.nbinput.container div[class*=highlight] pre,
-div.nboutput.container,
-div.nboutput.container div.prompt,
-div.nboutput.container div.output_area,
-div.nboutput.container div[class*=highlight],
-div.nboutput.container div[class*=highlight] pre {
-    background: none;
+div.nbinput.container div.prompt *,
+div.nboutput.container div.prompt *,
+div.nbinput.container div.input_area pre,
+div.nboutput.container div.output_area pre,
+div.nbinput.container div.input_area .highlight,
+div.nboutput.container div.output_area .highlight {
     border: none;
-    padding: 0 0;
+    padding: 0;
     margin: 0;
     box-shadow: none;
+}
+
+div.nbinput.container div.prompt *,
+div.nboutput.container div.prompt * {
+    background: none;
+}
+
+div.nboutput.container div.output_area .highlight,
+div.nboutput.container div.output_area pre {
+    background: unset;
+}
+
+div.nboutput.container div.output_area div.highlight {
+    color: unset;  /* override Pygments text color */
 }
 
 /* avoid gaps between output lines */
@@ -541,7 +550,7 @@ div.nboutput.container div.output_area {
 div.nbinput.container div.input_area {
     border: 1px solid #e0e0e0;
     border-radius: 2px;
-    background: #f5f5f5;
+    /*background: #f5f5f5;*/
 }
 
 /* override MathJax center alignment in output cells */
@@ -607,6 +616,7 @@ div.nboutput.container div.output_area.rendered_html,
 div.nboutput.container div.output_area > div.output_javascript,
 div.nboutput.container div.output_area:not(.rendered_html) > img{
     padding: 5px;
+    margin: 0;
 }
 
 /* fix copybtn overflow problem in chromium (needed for 'sphinx_copybutton') */


### PR DESCRIPTION
See #447.

I'm very unsure if that's actually a good idea.

Interestingly, most themes force their own background color, so this would only work with a subset of themes (e.g. with the RTD theme).

Apart from this, I'm hesitating because many people use the Pygments style `'sphinx'` (because it's the one used by `sphinx-quickstart`), which has a quite ugly green background.
If we were to merge this PR, many people would suddenly get a green background on their code cells (which they probably don't want).

Any comments/suggestions?