### PR TITLE
DOC: Remove copyright note from docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,7 +96,7 @@ master_doc = 'index'
 
 project = 'nbsphinx'
 author = 'Matthias Geier'
-copyright = '2020, ' + author
+html_show_copyright = False
 
 linkcheck_ignore = [
     r'http://localhost:\d+/',


### PR DESCRIPTION
This isn't necessary, the information should be clear from LICENSE.