### PR TITLE
CSS: disable margins from "basic" theme in code cells

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -438,6 +438,11 @@ div.nboutput.container div.output_area .highlight {
     box-shadow: none;
 }
 
+div.nbinput.container > div[class*=highlight],
+div.nboutput.container > div[class*=highlight] {
+    margin: 0;
+}
+
 div.nbinput.container div.prompt *,
 div.nboutput.container div.prompt * {
     background: none;


### PR DESCRIPTION
This has been changed in https://github.com/sphinx-doc/sphinx/commit/0dc6e3ac458dd6c10ed2c7bd03ca95bd694d7ec6, see also https://github.com/sphinx-doc/sphinx/pull/7657.

Rendered:
* https://311-210404706-gh.circle-artifacts.com/0/html/code-cells.html
* https://nbsphinx--494.org.readthedocs.build/en/494/code-cells.html