### PR TITLE
Handle empty cell outputs

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -204,6 +204,10 @@ RST_TEMPLATE = """
     .. raw:: html
 
         <script type="{{ datatype }}">{{ output.data[datatype] | json_dumps }}</script>
+{%- elif datatype == '' %}
+{# Empty output data #}
+
+    ..
 {% else %}
 
     .. nbwarning:: Data type cannot be displayed: {{ datatype }}

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -189,7 +189,7 @@ RST_TEMPLATE = """
 
     .. raw:: html
 
-{{ output.data['text/html'] | indent | indent }}
+{{ (output.data['text/html'] or '<!-- empty output -->') | indent | indent }}
 {%- elif datatype == 'application/javascript' %}
 
     .. raw:: html
@@ -255,19 +255,19 @@ RST_TEMPLATE = """
 {%- if raw_mimetype == '' %}
 .. raw:: html
 
-{{ cell.source | indent }}
+{{ (cell.source or '<!-- empty raw cell -->') | indent }}
 
 .. raw:: latex
 
-{{ cell.source | indent }}
+{{ (cell.source or '% empty raw cell') | indent }}
 {%- elif raw_mimetype == 'text/html' %}
 .. raw:: html
 
-{{ cell.source | indent }}
+{{ (cell.source or '<!-- empty raw cell -->') | indent }}
 {%- elif raw_mimetype == 'text/latex' %}
 .. raw:: latex
 
-{{ cell.source | indent }}
+{{ (cell.source or '% empty raw cell') | indent }}
 {%- elif raw_mimetype == 'text/markdown' %}
 {{ cell.source | markdown2rst }}
 {%- elif raw_mimetype == 'text/restructuredtext' %}


### PR DESCRIPTION
I guess empty outputs should not be in a notebook, but if they are, this led to a spurious warning: "Data type cannot be displayed:" (without mentioning an actual data type).

This happened e.g. in http://gallery.pangeo.io/repos/pangeo-data/pangeo-tutorial-gallery/geopandas.html

![image](https://user-images.githubusercontent.com/705404/95685156-676d2a80-0bf6-11eb-8ed5-5bad9082f05f.png)