### PR TITLE
Binder: explicitly install JupyterLab

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -2,3 +2,4 @@ matplotlib
 pandas
 ipywidgets
 jupytext
+jupyterlab>=2


### PR DESCRIPTION
Without that, there was an error while starting Binder.