### PR TITLE
Changed file: ... to environment: ..., in using Conda

### DIFF
--- a/doc/usage.ipynb
+++ b/doc/usage.ipynb
@@ -670,7 +670,7 @@
     "    version: 2\n",
     "    formats: all\n",
     "    conda:\n",
-    "      file: doc/environment.yml\n",
+    "      environment: doc/environment.yml\n",
     "    ```\n",
     "\n",
     "    For further options see https://docs.readthedocs.io/en/latest/config-file/.\n",
@@ -910,7 +910,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I changed
conda:
    file: docs/readthedocs-environment.yml
to 
conda:
    environment: docs/readthedocs-environment.yml
to conform with the documentation on https://docs.readthedocs.io/en/stable/config-file/v2.html#conda
The old way with file:.. doesn't work.