### PR TITLE
DOC: Add warning about warnings not working properly with nbconvert

### DIFF
--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -411,6 +411,18 @@
     "* No further attributes are allowed.\n",
     "* For compatibility with CommonMark, you should add an empty line between the `<div>` start tag and the beginning of the content.\n",
     "\n",
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "Warning\n",
+    "\n",
+    "While this works nicely with `nbsphinx`, JupyterLab and the Classic Jupyter Notebook,\n",
+    "This doesn't work correctly in `nbconvert`\n",
+    "and by extension on https://nbviewer.jupyter.org/ and Github's notebook preview.\n",
+    "\n",
+    "See https://github.com/jupyter/nbconvert/issues/1125.\n",
+    "\n",
+    "</div>\n",
+    "\n",
     "<div class=\"alert alert-info\">\n",
     "\n",
     "Note\n",
@@ -572,7 +584,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.9.1rc1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Rendered: https://nbsphinx--521.org.readthedocs.build/en/521/markdown-cells.html#Info/Warning-Boxes