### PR TITLE
DOC: change alt text of Python logo attachment

### DIFF
--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -337,7 +337,7 @@
     "\n",
     "These are cell attachments: ![a stick figure](attachment:stickfigure.png)\n",
     "\n",
-    "![Python logo](attachment:98a753bb-02aa-42e8-81da-6a5c4f9b8eb5.png)\n",
+    "![small Python logo](attachment:98a753bb-02aa-42e8-81da-6a5c4f9b8eb5.png)\n",
     "\n",
     "In the Jupyter Notebook, there is a speciall \"Attachments\" cell toolbar which you can use to see all attachments of a cell and delete them, if needed."
    ]


### PR DESCRIPTION
This caused the warning:

    doc/markdown-cells.ipynb:401: WARNING: Duplicate substitution definition name: "Python logo".

The problem is that duplicate `alt` names are currently possible *in the same* Markdown cell, but they are not supported in different cells of the same notebook.