### PR TITLE
Add footcite feature

### DIFF
--- a/doc/a-normal-rst-file.rst
+++ b/doc/a-normal-rst-file.rst
@@ -176,7 +176,7 @@ There are different ways of handling references, for example you could use the
 sphinxcontrib.bibtex_ extension.
 
 After installing the sphinxcontrib.bibtex_ extension, you have to enable it in
-your ``conf.py`` and select at least one BibTeX file you want to use:
+your ``conf.py`` and select the BibTeX file(s) you want to use:
 
 .. code-block:: python
 
@@ -189,7 +189,7 @@ your ``conf.py`` and select at least one BibTeX file you want to use:
     bibtex_bibfiles = ['my-references.bib']
 
 Afterwards all the references defined in the bibliography file(s) can be used
-throughout the documents as detailed in the following.
+throughout the Jupyter notebooks and other source files as detailed in the following.
 
 .. _standard Sphinx Citations: https://www.sphinx-doc.org/en/master/usage/
     restructuredtext/basics.html#citations
@@ -241,8 +241,8 @@ citations like :footcite:`perez2011python`.
 Also footnote citations can be used within Jupyter notebooks with a special HTML syntax,
 see the section about 
 `footnote citations in Markdown cells <markdown-cells.ipynb#Footnote-citations>`__.
-Footnote citations are restricted to their own document and the assembly of the 
-bibliography is (analogously to citations) invoked with the
+Footnote citations are restricted to their own source file and the assembly of the 
+bibliography is (analogously to normal citations) invoked with the
 
 .. code-block:: rst
 
@@ -254,8 +254,8 @@ look like this (in HTML output):
 .. footbibliography::
 
 In the LaTeX/PDF output, there is no list of references appearing right 
-here or anywhere else in the document. Instead, the footnote citations 
-are placed into the footnotes of their respective pages.
+here. Instead, the footnote citations are placed into the footnotes of 
+their respective pages.
 
 
 Thumbnail Galleries

--- a/doc/a-normal-rst-file.rst
+++ b/doc/a-normal-rst-file.rst
@@ -167,36 +167,16 @@ Domain Objects
 
         :ref:`/markdown-cells.ipynb#Links-to-Domain-Objects`
 
-Citations
----------
-
-You could use `standard Sphinx citations`_, but it might be more practical to
-use the sphinxcontrib.bibtex_ extension.
-
-If you install and enable this extension,
-you can create citations like :cite:`perez2011python`:
-
-.. code-block:: rst
-
-    :cite:`perez2011python`
-
-You can create similar citations in Jupyter notebooks with a special HTML
-syntax, see the section about `citations in Markdown cells`_.
-
-.. _standard Sphinx Citations: https://www.sphinx-doc.org/en/master/usage/
-    restructuredtext/basics.html#citations
-.. _sphinxcontrib.bibtex: https://sphinxcontrib-bibtex.readthedocs.io/
-.. _citations in Markdown cells: markdown-cells.ipynb#Citations
-
-For those citations to work, you also need to specify a BibTeX file,
-as explained in the next section.
-
 
 References
 ----------
 
+There are different ways of handling references, for example you could use the 
+`standard Sphinx citations`_, but it might be more practical to use the 
+sphinxcontrib.bibtex_ extension.
+
 After installing the sphinxcontrib.bibtex_ extension, you have to enable it in
-your ``conf.py`` and select the BibTeX file(s) you want to use:
+your ``conf.py`` and select at least one BibTeX file you want to use:
 
 .. code-block:: python
 
@@ -208,7 +188,27 @@ your ``conf.py`` and select the BibTeX file(s) you want to use:
 
     bibtex_bibfiles = ['my-references.bib']
 
-Then you can create a list of references in any reStructuredText file
+Afterwards all the references defined in the bibliography file(s) can be used
+throughout the documents as detailed in the following.
+
+.. _standard Sphinx Citations: https://www.sphinx-doc.org/en/master/usage/
+    restructuredtext/basics.html#citations
+.. _sphinxcontrib.bibtex: https://sphinxcontrib-bibtex.readthedocs.io/
+
+Citations
+^^^^^^^^^
+
+You can create citations like :cite:`perez2011python`:
+
+.. code-block:: rst
+
+    :cite:`perez2011python`
+
+You can create similar citations in Jupyter notebooks with a special HTML
+syntax, see the section about 
+`citations in Markdown cells <markdown-cells.ipynb#Citations>`__.
+
+You can create a list of references in any reStructuredText file
 (or `reST cell <raw-cells.ipynb#reST>`_ in a notebook) like this:
 
 .. code-block:: rst
@@ -227,6 +227,9 @@ but at the end of the document.
 For a possible work-around,
 see https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/156.
 
+Footnote citations
+^^^^^^^^^^^^^^^^^^
+
 With a sphinxcontrib.bibtex_ version of ``>= 2.0.0`` it is 
 possible to create footnote bibliographies with footnote 
 citations like :footcite:`perez2011python`.
@@ -235,8 +238,11 @@ citations like :footcite:`perez2011python`.
 
     :footcite:`perez2011python`
 
-These citations are restricted to their own document and the assembly of the
-bibliography is invoked with the
+Also footnote citations can be used within Jupyter notebooks with a special HTML syntax,
+see the section about 
+`footnote citations in Markdown cells <markdown-cells.ipynb#Footnote-citations>`__.
+Footnote citations are restricted to their own document and the assembly of the 
+bibliography is (analogously to citations) invoked with the
 
 .. code-block:: rst
 
@@ -250,10 +256,6 @@ look like this (in HTML output):
 In the LaTeX/PDF output, there is no list of references appearing right 
 here or anywhere else in the document. Instead, the footnote citations 
 are placed into the footnotes of their respective pages.
-
-There is an alternative Sphinx extension for creating bibliographies:
-``https://bitbucket.org/wnielson/sphinx-natbib/``.
-However, this project seems to be abandoned (last commit in 2011).
 
 
 Thumbnail Galleries

--- a/doc/a-normal-rst-file.rst
+++ b/doc/a-normal-rst-file.rst
@@ -227,6 +227,30 @@ but at the end of the document.
 For a possible work-around,
 see https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/156.
 
+With a sphinxcontrib.bibtex_ version of ``>= 2.0.0`` it is 
+possible to create footnote bibliographies with footnote 
+citations like :footcite:`perez2011python`.
+
+.. code-block:: rst
+
+    :footcite:`perez2011python`
+
+These citations are restricted to their own document and the assembly of the
+bibliography is invoked with the
+
+.. code-block:: rst
+
+    .. footbibliography::
+
+directive. For example, a footnote bibliography might 
+look like this (in HTML output):
+
+.. footbibliography::
+
+In the LaTeX/PDF output, there is no list of references appearing right 
+here or anywhere else in the document. Instead, the footnote citations 
+are placed into the footnotes of their respective pages.
+
 There is an alternative Sphinx extension for creating bibliographies:
 ``https://bitbucket.org/wnielson/sphinx-natbib/``.
 However, this project seems to be abandoned (last commit in 2011).

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -208,7 +208,7 @@
     "\n",
     "### Footnote citations\n",
     "\n",
-    "Since version `2.0.0` of sphinxcontrib-bibtex, [footnote citations](https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#role-footcite) are possible. This generates footnotes for all foot-citations up to the point of the bibliography directive, which is typically placed at the end of the document. \n",
+    "Since version `2.0.0` of sphinxcontrib-bibtex, [footnote citations](https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#role-footcite) are possible. This generates footnotes for all foot-citations up to the point of the bibliography directive, which is typically placed at the end of the source file.\n",
     "\n",
     "Depending on whether the documentation is rendered into HTML or into LaTeX/PDF, the citations are either placed into a bibliography as ordinary citations (HTML output) or placed into the footnotes of the citation's respective page (PDF).\n",
     "\n",
@@ -218,19 +218,13 @@
     "<cite data-footcite=\"perez2011python\">Pérez et al. (2011)</cite>\n",
     "```\n",
     "\n",
-    "As footnote references are restricted to their own document, a raw nbconvert cell of reST format (see [the section about raw cells](raw-cells.ipynb)) can be added to the notebook, containing the\n",
+    "As footnote references are restricted to their own Jupyter notebook or other source file, a raw nbconvert cell of reST format (see [the section about raw cells](raw-cells.ipynb)) can be added to the notebook, containing the\n",
     "\n",
     "```rst\n",
     ".. footbibliography::\n",
     "```\n",
     "\n",
-    "directive. Alternatively, one can use the [nbsphinx epilog](prolog-and-epilog.ipynb) by setting it to, e.g.,\n",
-    "\n",
-    "```python\n",
-    "nbsphinx_epilog = r\"\"\"\n",
-    ".. footbibliography::\n",
-    "\"\"\"\n",
-    "```"
+    "directive."
    ]
   },
   {
@@ -240,6 +234,19 @@
    },
    "source": [
     ".. footbibliography::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, one can use the [nbsphinx epilog](prolog-and-epilog.ipynb) by setting it to, e.g.,\n",
+    "\n",
+    "```python\n",
+    "nbsphinx_epilog = r\"\"\"\n",
+    ".. footbibliography::\n",
+    "\"\"\"\n",
+    "```"
    ]
   },
   {

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -206,6 +206,8 @@
     "\n",
     "There is also a Notebook extension which may or may not be useful: https://github.com/takluyver/cite2c.\n",
     "\n",
+    "### Footnote citations\n",
+    "\n",
     "Since version `2.0.0` of sphinxcontrib-bibtex, [footnote citations](https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#role-footcite) are possible. This generates footnotes for all foot-citations up to the point of the bibliography directive, which is typically placed at the end of the document. \n",
     "\n",
     "Depending on whether the documentation is rendered into HTML or into LaTeX/PDF, the citations are either placed into a bibliography as ordinary citations (HTML output) or placed into the footnotes of the citation's respective page (PDF).\n",
@@ -623,7 +625,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -204,7 +204,32 @@
     "You'll also have to define a list of references,\n",
     "see [the section about references](a-normal-rst-file.rst#references).\n",
     "\n",
-    "There is also a Notebook extension which may or may not be useful: https://github.com/takluyver/cite2c."
+    "There is also a Notebook extension which may or may not be useful: https://github.com/takluyver/cite2c.\n",
+    "\n",
+    "Since version `2.0.0` of sphinxcontrib-bibtex, [footnote citations](https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#role-footcite) are possible. This generates footnotes for all foot-citations up to the point of the bibliography directive; typically placed at the end of the document.\n",
+    "\n",
+    "Example: <cite data-footcite=\"perez2011python\">Pérez et al. (2011)</cite>.\n",
+    "\n",
+    "```html\n",
+    "<cite data-footcite=\"perez2011python\">Pérez et al. (2011)</cite>\n",
+    "```\n",
+    "\n",
+    "As footnote references are restricted to their own document, a raw nbconvert cell of reST format (see [the section about raw cells](raw-cells.ipynb)) has to be added to the notebook, containing the\n",
+    "\n",
+    "```rst\n",
+    ".. footbibliography::\n",
+    "```\n",
+    "\n",
+    "directive. This causes a bibliography to be rendered in HTML output, in LaTeX/PDF output it references all the (foot)citations in the footnotes on their respective pages."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    ".. footbibliography::"
    ]
   },
   {
@@ -574,6 +599,7 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Raw Cell Format",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -589,7 +615,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -206,7 +206,9 @@
     "\n",
     "There is also a Notebook extension which may or may not be useful: https://github.com/takluyver/cite2c.\n",
     "\n",
-    "Since version `2.0.0` of sphinxcontrib-bibtex, [footnote citations](https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#role-footcite) are possible. This generates footnotes for all foot-citations up to the point of the bibliography directive; typically placed at the end of the document.\n",
+    "Since version `2.0.0` of sphinxcontrib-bibtex, [footnote citations](https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#role-footcite) are possible. This generates footnotes for all foot-citations up to the point of the bibliography directive, which is typically placed at the end of the document. \n",
+    "\n",
+    "Depending on whether the documentation is rendered into HTML or into LaTeX/PDF, the citations are either placed into a bibliography as ordinary citations (HTML output) or placed into the footnotes of the citation's respective page (PDF).\n",
     "\n",
     "Example: <cite data-footcite=\"perez2011python\">Pérez et al. (2011)</cite>.\n",
     "\n",
@@ -214,13 +216,19 @@
     "<cite data-footcite=\"perez2011python\">Pérez et al. (2011)</cite>\n",
     "```\n",
     "\n",
-    "As footnote references are restricted to their own document, a raw nbconvert cell of reST format (see [the section about raw cells](raw-cells.ipynb)) has to be added to the notebook, containing the\n",
+    "As footnote references are restricted to their own document, a raw nbconvert cell of reST format (see [the section about raw cells](raw-cells.ipynb)) can be added to the notebook, containing the\n",
     "\n",
     "```rst\n",
     ".. footbibliography::\n",
     "```\n",
     "\n",
-    "directive. This causes a bibliography to be rendered in HTML output, in LaTeX/PDF output it references all the (foot)citations in the footnotes on their respective pages."
+    "directive. Alternatively, one can use the [nbsphinx epilog](prolog-and-epilog.ipynb) by setting it to, e.g.,\n",
+    "\n",
+    "```python\n",
+    "nbsphinx_epilog = r\"\"\"\n",
+    ".. footbibliography::\n",
+    "\"\"\"\n",
+    "```"
    ]
   },
   {
@@ -615,7 +623,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -208,7 +208,7 @@
     "\n",
     "### Footnote citations\n",
     "\n",
-    "Since version `2.0.0` of sphinxcontrib-bibtex, [footnote citations](https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#role-footcite) are possible. This generates footnotes for all foot-citations up to the point of the bibliography directive, which is typically placed at the end of the source file.\n",
+    "Since version `2.0.0` of sphinxcontrib-bibtex, [footnote citations](https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html#role-footcite) are possible. This generates footnotes for all foot-citations up to the point of the [bibliography directive](a-normal-rst-file.rst#footnote-citations), which is typically placed at the end of the source file.\n",
     "\n",
     "Depending on whether the documentation is rendered into HTML or into LaTeX/PDF, the citations are either placed into a bibliography as ordinary citations (HTML output) or placed into the footnotes of the citation's respective page (PDF).\n",
     "\n",

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -1266,6 +1266,9 @@ class CitationParser(html.parser.HTMLParser):
             if name == 'data-cite':
                 self.cite = ':cite:`' + value + '`'
                 return True
+            elif name == 'data-footcite':
+                self.cite = ':footcite:`' + value + '`'
+                return True
         return False
 
     def reset(self):


### PR DESCRIPTION
Hi,
as mentioned in issue #535, this adds the `data-footcite` attribute to the `CitationParser`. One could check if there are both `data-cite` and `data-footcite` present inside the HTML tag, however I think that is a fairly exotic case. In this implementations' current state, the attribute that comes first would simply take precedence. I took the liberty to update the documentation notebooks accordingly.
Please let me know if you have any suggestions!

**Source**:

![footbibliography_source](https://user-images.githubusercontent.com/1685266/107213404-a4acc200-6a08-11eb-8a9a-1211c5b651e0.png)

**Result**:
![footbibliography_result](https://user-images.githubusercontent.com/1685266/107213471-c1e19080-6a08-11eb-96f6-20836095108b.png)