### PR TITLE
process cell tags remove-input and remove-output

### DIFF
--- a/doc/hidden-cells.ipynb
+++ b/doc/hidden-cells.ipynb
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -47,9 +47,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "42"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "answer"
    ]
@@ -79,6 +90,64 @@
    "source": [
     "This is the cell after the hidden cell."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hidden input and output\n",
+    "\n",
+    "You can also only remove input and output of a notebook using the `remove-input` and `remove-output` cell tags.\n",
+    "This is different from the metadata change for hiding everything, but is compatible with Jupyter Book."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tags": [
+     "remove-output"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Cell with hidden output'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"Cell with hidden output\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Did you see the input?'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"Did you see the input?\""
+   ]
   }
  ],
  "metadata": {
@@ -97,7 +166,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.9.1+"
   }
  },
  "nbformat": 4,

--- a/doc/hidden-cells.ipynb
+++ b/doc/hidden-cells.ipynb
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -47,20 +47,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "42"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
+   "source": [
+    "answer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another way to hide sphinx is by adding a `remove-cell` cell tag. This is compatible with Jupyter Book."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
    "source": [
     "answer"
    ]
@@ -98,53 +107,31 @@
     "## Hidden input and output\n",
     "\n",
     "You can also only remove input and output of a notebook using the `remove-input` and `remove-output` cell tags.\n",
-    "This is different from the metadata change for hiding everything, but is compatible with Jupyter Book."
+    "Unlike for hiding entire cells, no metadata-based hiding of input and output is provided."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Cell with hidden output'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"Cell with hidden output\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Did you see the input?'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"Did you see the input?\""
    ]
@@ -166,7 +153,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1+"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -103,7 +103,7 @@ RST_TEMPLATE = """
 
 
 {% block any_cell %}
-{%- if cell.metadata.nbsphinx != 'hidden' %}
+{%- if cell.metadata.nbsphinx != 'hidden' and 'remove-cell' not in cell.metadata.tags %}
 {{ super() }}
 ..
 {# Empty comment to make sure the preceding directive (if any) is closed #}

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -112,6 +112,7 @@ RST_TEMPLATE = """
 
 
 {% block input -%}
+{% if 'remove-input' not in cell.metadata.tags %}
 .. nbinput:: {% if cell.metadata.magics_language -%}
 {{ cell.metadata.magics_language }}
 {%- elif nb.metadata.language_info -%}
@@ -128,6 +129,7 @@ RST_TEMPLATE = """
 {%- endif %}
 
 {{ cell.source.strip('\n') | indent }}
+{% endif %}
 {% endblock input %}
 
 
@@ -216,6 +218,7 @@ RST_TEMPLATE = """
 
 
 {% block nboutput -%}
+{% if 'remove-output' not in cell.metadata.tags %}
 ..
 {# Empty comment to make sure the preceding directive (if any) is closed #}
 {%- set html_datatype, latex_datatype = output | get_output_type %}
@@ -228,6 +231,7 @@ RST_TEMPLATE = """
 .. only:: latex
 
 {{ insert_nboutput(latex_datatype, output, cell) | indent }}
+{% endif %}
 {% endif %}
 {% endblock nboutput %}
 

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -103,7 +103,7 @@ RST_TEMPLATE = """
 
 
 {% block any_cell %}
-{%- if cell.metadata.nbsphinx != 'hidden' and 'remove-cell' not in cell.metadata.tags %}
+{%- if cell.metadata.nbsphinx != 'hidden' %}
 {{ super() }}
 ..
 {# Empty comment to make sure the preceding directive (if any) is closed #}
@@ -112,7 +112,6 @@ RST_TEMPLATE = """
 
 
 {% block input -%}
-{% if 'remove-input' not in cell.metadata.tags %}
 .. nbinput:: {% if cell.metadata.magics_language -%}
 {{ cell.metadata.magics_language }}
 {%- elif nb.metadata.language_info -%}
@@ -129,7 +128,6 @@ RST_TEMPLATE = """
 {%- endif %}
 
 {{ cell.source.strip('\n') | indent }}
-{% endif %}
 {% endblock input %}
 
 
@@ -218,7 +216,6 @@ RST_TEMPLATE = """
 
 
 {% block nboutput -%}
-{% if 'remove-output' not in cell.metadata.tags %}
 ..
 {# Empty comment to make sure the preceding directive (if any) is closed #}
 {%- set html_datatype, latex_datatype = output | get_output_type %}
@@ -231,7 +228,6 @@ RST_TEMPLATE = """
 .. only:: latex
 
 {{ insert_nboutput(latex_datatype, output, cell) | indent }}
-{% endif %}
 {% endif %}
 {% endblock nboutput %}
 
@@ -789,6 +785,12 @@ class Exporter(nbconvert.RSTExporter):
                 'HighlightMagicsPreprocessor': {'enabled': True},
                 # Work around https://github.com/jupyter/nbconvert/issues/720:
                 'RegexRemovePreprocessor': {'enabled': False},
+                'TagRemovePreprocessor': {
+                    'enabled': True,
+                    'remove_cell_tags': ('remove-cell',),
+                    'remove_all_outputs_tags': ('remove-output',),
+                    'remove_input_tags': ('remove-input',),
+                },
             }),
             filters={
                 'convert_pandoc': convert_pandoc,


### PR DESCRIPTION
This PR adds removing cell input and output by using the `remove-input` and `remove-output` tags.

My understanding from #436 is that the behaviour (remove output rather than hide with css) is consistent with Jupyter Book use of the same tags.
This is complimentary to #436 in that it deals with `remove-` tags as opposed to `hide-*`.

Thank you for looking at this, and making nbsphinx in the first place!