### PR TITLE
CI: add Github action for building HTML on macOS

### DIFF
--- a/.github/workflows/html-macos.yml
+++ b/.github/workflows/html-macos.yml
@@ -1,0 +1,29 @@
+name: Build HTML on macOS
+on: [push, pull_request]
+jobs:
+  html-macos:
+    runs-on: macos-latest
+    steps:
+    - name: Clone repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Install pandoc
+      run: |
+        brew install pandoc
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3
+    - name: Double-check Python version
+      run: |
+        python --version
+    - name: Install Python package
+      run: |
+        python -m pip install .
+    - name: Install docs dependencies
+      run: |
+        python -m pip install -r doc/requirements.txt
+    - name: Build HTML
+      run: |
+        python -m sphinx -W --keep-going --color doc/ _build/html/


### PR DESCRIPTION
This causes a warning about `rsvg`, even though it should not be needed for HTML builds.

```
Running Sphinx v3.5.4
...
WARNING: RSVG converter command 'rsvg-convert' cannot be run. Check the rsvg_converter_bin setting
...
```

See https://github.com/missinglinkelectronics/sphinxcontrib-svg2pdfconverter/issues/8.