### PR TITLE
DOC: Show how to use Markdown source files

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -1,5 +1,5 @@
 This folder contains the source files for the documentation.
-See [CONTRIBUTING](../CONTRIBUTING.rst) for how to create the HTML and LaTeX
+See ../CONTRIBUTING.rst for how to create the HTML and LaTeX
 files from these sources.
 
 The online documentation is available at https://nbsphinx.readthedocs.io/.

--- a/doc/a-markdown-file.md
+++ b/doc/a-markdown-file.md
@@ -1,0 +1,36 @@
+# Using Markdown Files
+
+It is possible to use Markdown source files, as explained in the
+[Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/markdown.html).
+
+The Python package ``myst-parser`` has to be installed and
+``conf.py`` should at least contain this:
+
+```python
+extensions = [
+    'nbsphinx',
+    'myst_parser',
+]
+
+myst_update_mathjax = False
+```
+
+
+## Links to Notebooks (and Other Sphinx Source Files)
+
+Links to Sphinx source files can be created like in
+[Markdown cells of notebooks](markdown-cells.html#Links-to-Other-Notebooks).
+
+
+## Math
+
+Math equation can be used just like in
+[Markdown cells of notebooks](markdown-cells.html#Equations).
+
+Inline like this: $\text{e}^{i\pi} = -1$.
+
+Or as a separate block:
+
+\begin{equation}
+\int\limits_{-\infty}^\infty f(x) \delta(x - x_0) dx = f(x_0)
+\end{equation}

--- a/doc/a-markdown-file.md
+++ b/doc/a-markdown-file.md
@@ -19,13 +19,13 @@ myst_update_mathjax = False
 ## Links to Notebooks (and Other Sphinx Source Files)
 
 Links to Sphinx source files can be created like in
-[Markdown cells of notebooks](markdown-cells.html#Links-to-Other-Notebooks).
+[Markdown cells of notebooks](markdown-cells.ipynb#Links-to-Other-Notebooks).
 
 
 ## Math
 
 Math equation can be used just like in
-[Markdown cells of notebooks](markdown-cells.html#Equations).
+[Markdown cells of notebooks](markdown-cells.ipynb#Equations).
 
 Inline like this: $\text{e}^{i\pi} = -1$.
 

--- a/doc/a-markdown-file.md
+++ b/doc/a-markdown-file.md
@@ -31,6 +31,6 @@ Inline like this: $\text{e}^{i\pi} = -1$.
 
 Or as a separate block:
 
-\begin{equation}
+\begin{equation*}
 \int\limits_{-\infty}^\infty f(x) \delta(x - x_0) dx = f(x_0)
-\end{equation}
+\end{equation*}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -85,6 +85,8 @@ nbsphinx_custom_formats = {
 
 myst_update_mathjax = False
 
+myst_enable_extensions = ['dollarmath', 'amsmath']
+
 # -- The settings below this line are not specific to nbsphinx ------------
 
 master_doc = 'index'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,6 +10,7 @@ extensions = [
     'sphinxcontrib.rsvgconverter',  # for SVG->PDF conversion in LaTeX output
     'sphinx_gallery.load_style',  # load CSS for gallery (needs SG >= 0.6)
     'sphinx_last_updated_by_git',  # get "last updated" from Git
+    'myst_parser',  # for Markdown source files
 ]
 
 # Don't add .txt suffix to source files:
@@ -81,6 +82,8 @@ bibtex_bibfiles = ['references.bib']
 nbsphinx_custom_formats = {
     '.pct.py': ['jupytext.reads', {'fmt': 'py:percent'}],
 }
+
+myst_update_mathjax = False
 
 # -- The settings below this line are not specific to nbsphinx ------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,6 +20,7 @@ was generated from Jupyter notebooks.
     subdir/*
     custom-css
     a-normal-rst-file
+    a-markdown-file
     links
     contributing
     version-history

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,3 +8,4 @@ ipywidgets
 sphinx-gallery
 jupytext
 sphinx-last-updated-by-git
+myst-parser


### PR DESCRIPTION
This is WIP because block math doesn't work yet.

It would also be great to avoid having to specify `myst_update_mathjax`.

Rendered: https://nbsphinx--560.org.readthedocs.build/en/560/a-markdown-file.html