### PR TITLE
Explicitly import sphinx.directives.other

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -43,6 +43,7 @@ import nbconvert
 import nbformat
 import sphinx
 import sphinx.directives
+import sphinx.directives.other
 import sphinx.environment
 import sphinx.errors
 import sphinx.transforms.post_transforms.images


### PR DESCRIPTION
This seems to have caused errors on Travis-CI.