### PR TITLE
Freeze Jinja2 version to 2.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     python_requires='>=3.6',
     install_requires=[
         'docutils',
-        'jinja2',
+        'jinja2~=2.11',
         'nbconvert!=5.4',
         'traitlets',
         'nbformat',


### PR DESCRIPTION
I mentioned in https://github.com/spatialaudio/nbsphinx/issues/563 that the new Jinja2 version breaks nbsphinx.

This is a simple workaround to freeze Jinja2 version to 2.11.
Refactoring nbsphinx to support Jinja2 3.x is probably wise at some point but this should work for now