### PR TITLE
Respect github_url field in nbsphinx_prolog

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -1051,11 +1051,11 @@ class NotebookParser(rst.Parser):
 
         if resources.get('nbsphinx_orphan', False):
             rst.Parser.parse(self, ':orphan:', document)
-        rst.Parser.parse(self, '.. highlight:: none', document)
         if env.config.nbsphinx_prolog:
             prolog = exporter.environment.from_string(
                 env.config.nbsphinx_prolog).render(env=env)
             rst.Parser.parse(self, prolog, document)
+        rst.Parser.parse(self, '.. highlight:: none', document)
         rst.Parser.parse(self, rststring, document)
         if env.config.nbsphinx_epilog:
             epilog = exporter.environment.from_string(


### PR DESCRIPTION
Hi nbsphinx devs, I'm not sure if this is a proper fix but it resolves a problem that I faced recently with `nbsphinx>=0.8.2`: the `github_url` metadata is not respected when the page is rendered (see e.g. [this page](http://num.pyro.ai/en/stable/tutorials/bayesian_regression.html)). Currently, we define `github_url` in [nbsphinx_prolog](https://github.com/pyro-ppl/numpyro/blob/94040410a0e63de49fdbab1f0a48f7f8d15073b2/docs/source/conf.py#L136) so that `Edit on GitHub` points to the right location on github.