### PR TITLE
Added note how to format bulletpoints

### DIFF
--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -24,7 +24,7 @@
     "* Blue\n",
     "\n",
     "Note: JupyterLab and JupyterNotebook uses a different Markdown parser than nbsphinx (which currently uses Pandoc). \n",
-    "In case that your Bulletpoints do render in the notebook and do not render with nbsphinx, please add one blank line before the bulletpoints. Your lists will then render correctly in the spinx build.\n",
+    "In case that your Bulletpoints do render in the notebook and do not render with nbsphinx, please add one blank line before the bulletpoints.\n",
     "***\n",
     "\n",
     "1. One\n",

--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -23,6 +23,8 @@
     "* Green\n",
     "* Blue\n",
     "\n",
+    "Note: JupyterLab and JupyterNotebook uses a different Markdown parser than nbsphinx (which currently uses Pandoc). \n",
+    "In case that your Bulletpoints do render in the notebook and do not render with nbsphinx, please add one blank line before the bulletpoints. Your lists will then render correctly in the spinx build.\n",
     "***\n",
     "\n",
     "1. One\n",
@@ -642,7 +644,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I did not know that one has to add one blank line before bullet points, but @mgeier showed me so in #574.
As Jupyter notebooks do not require this blank line locally, this can get a bit confusing.
This note will help people in the future, who might have the same problem as I had.