### PR TITLE
Improve MathJax compatibility with myst-parser

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -1889,7 +1889,7 @@ def config_inited(app, config):
         mathjax3_config['tex'] = tex
         options = {
             'ignoreHtmlClass': 'document',
-            'processHtmlClass': 'math|output_area',
+            'processHtmlClass': 'tex2jax_process|mathjax_process|math|output_area',
         }
         options.update(mathjax3_config.get('options', {}))
         mathjax3_config['options'] = options
@@ -1908,7 +1908,7 @@ def config_inited(app, config):
             'inlineMath': [['$', '$'], ['\\(', '\\)']],
             'processEscapes': True,
             'ignoreClass': 'document',
-            'processClass': 'math|output_area',
+            'processClass': 'tex2jax_process|mathjax_process|math|output_area',
         }
         tex2jax.update(mathjax2_config.get('tex2jax', {}))
         mathjax2_config['tex2jax'] = tex2jax

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -1889,7 +1889,8 @@ def config_inited(app, config):
         mathjax3_config['tex'] = tex
         options = {
             'ignoreHtmlClass': 'document',
-            'processHtmlClass': 'tex2jax_process|mathjax_process|math|output_area',
+            'processHtmlClass':
+            'tex2jax_process|mathjax_process|math|output_area',
         }
         options.update(mathjax3_config.get('options', {}))
         mathjax3_config['options'] = options
@@ -1908,7 +1909,8 @@ def config_inited(app, config):
             'inlineMath': [['$', '$'], ['\\(', '\\)']],
             'processEscapes': True,
             'ignoreClass': 'document',
-            'processClass': 'tex2jax_process|mathjax_process|math|output_area',
+            'processClass':
+            'tex2jax_process|mathjax_process|math|output_area',
         }
         tex2jax.update(mathjax2_config.get('tex2jax', {}))
         mathjax2_config['tex2jax'] = tex2jax


### PR DESCRIPTION
Heya, this would meet me halfway with https://github.com/executablebooks/MyST-Parser/pull/395, so both packages will share the same `processClass` regex (and myst-parser won't complain about overriding it).
Plus anyway it is slightly better for compatibility with any advanced use cases, so people can still use the MathJax standard classes `tex2jax_process` (mathjax2) and `mathjax_process` (mathjax3).