### PR TITLE
doc fix: --InlineBackend.rc=figure.dpi=96 => dict

### DIFF
--- a/doc/code-cells.ipynb
+++ b/doc/code-cells.ipynb
@@ -362,7 +362,7 @@
     "```python\n",
     "nbsphinx_execute_arguments = [\n",
     "    \"--InlineBackend.figure_formats={'svg', 'pdf'}\",\n",
-    "    \"--InlineBackend.rc=figure.dpi=96\",\n",
+    "    \"--InlineBackend.rc={'figure.dpi': 96}\",\n",
     "]\n",
     "```\n",
     "    \n",


### PR DESCRIPTION
The docs suggest adding `--InlineBackend.rc=figure.dpi=96` to `nbsphinx_execute_arguments` in `conf.py` -- but this will lead to nbsphinx complaining about .rc not being a dict. This changes the suggestion to be `--InlineBackend.rc={'figure.dpi': 96}`