### PR TITLE
fix: avoid closing the script tag early by escaping a forward slash

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -284,7 +284,7 @@ RST_TEMPLATE = """
 .. raw:: html
 
     <script type="application/vnd.jupyter.widget-state+json">
-    {{ nb.metadata.widgets['application/vnd.jupyter.widget-state+json'] | json_dumps }}
+    {{ nb.metadata.widgets['application/vnd.jupyter.widget-state+json'] | json_dumps | escape_html_script }}
     </script>
 {% endif %}
 {{ super() }}


### PR DESCRIPTION
Same as https://github.com/jupyter/nbconvert/pull/1665

Requires a new release of nbconvert as well