### PR TITLE
Change internal representation of _BROKEN_THUMBNAIL

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -61,7 +61,7 @@ _ipynbversion = 4
 
 logger = sphinx.util.logging.getLogger(__name__)
 
-_BROKEN_THUMBNAIL = object()
+_BROKEN_THUMBNAIL = None
 
 # See nbconvert/exporters/html.py:
 DISPLAY_DATA_PRIORITY_HTML = (
@@ -2356,5 +2356,5 @@ def setup(app):
         'version': __version__,
         'parallel_read_safe': True,
         'parallel_write_safe': True,
-        'env_version': 3,
+        'env_version': 4,
     }


### PR DESCRIPTION
When re-building the docs after a change, and the previous build information is read from Sphinx's cache, the `_BROKEN_THUMBNAIL` was un-pickled as a different `object` instance (from a previous invocation), leading to an error.

Using `None` should yield the identical object after pickling.

Let's hope this doesn't lead to different problems ...