### PR TITLE
CSS: update for hiding copy button in prompts

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -644,7 +644,7 @@ div.nboutput.container div.output_area > div[class^='highlight']{
 }
 
 /* hide copybtn icon on prompts (needed for 'sphinx_copybutton') */
-.prompt a.copybtn {
+.prompt .copybtn {
     display: none;
 }
 


### PR DESCRIPTION
In previous versions, `<a>` has been used, in newer versions they seem to have changed to `<button>`.

This PR can handle both.

Fixes #607.