### PR TITLE
Escape </script> tags in JSON data

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -795,7 +795,12 @@ class Exporter(nbconvert.RSTExporter):
                 'save_attachments': save_attachments,
                 'replace_attachments': replace_attachments,
                 'get_output_type': _get_output_type,
-                'json_dumps': json.dumps,
+                'json_dumps': lambda s: re.sub(
+                    r'<(/script)',
+                    r'<\\\1',
+                    json.dumps(s),
+                    flags=re.IGNORECASE,
+                ),
                 'basename': os.path.basename,
                 'dirname': os.path.dirname,
             })


### PR DESCRIPTION
This is a variation of #606 and it closes #183.

This can handle a few more edge cases than the original fix in `nbconvert`: https://github.com/jupyter/nbconvert/pull/1665.

For example, it can handle a cell like this:

```python
ipywidgets.Label('using </scRIPt can be problematic')
```