### PR TITLE
Insert autolink-concat directive into notebooks if sphinx_codeautolink is loaded

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -1061,6 +1061,8 @@ class NotebookParser(rst.Parser):
                 env.config.nbsphinx_prolog).render(env=env)
             rst.Parser.parse(self, prolog, document)
         rst.Parser.parse(self, '.. highlight:: none', document)
+        if 'sphinx_codeautolink' in env.config.extensions:
+            rst.Parser.parse(self, '.. autolink-concat:: on', document)
         rst.Parser.parse(self, rststring, document)
         if env.config.nbsphinx_epilog:
             epilog = exporter.environment.from_string(


### PR DESCRIPTION
The Sphinx extension https://github.com/felix-hilden/sphinx-codeautolink by default considers code blocks separately. In Jupyter notebooks, however, all code cells share the same namespace and should be concatenated by default.