### PR TITLE
Avoid empty "raw" directive

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -162,9 +162,12 @@ RST_TEMPLATE = """
 {{ output.data[datatype] | escape_latex | ansi2latex | indent | indent }}
         \\end{sphinxVerbatim}
 
+{# NB: The "raw" directive doesn't work with empty content #}
+{%- if output.data[datatype].strip() %}
     .. raw:: text
 
 {{ output.data[datatype] | indent | indent }}
+{%- endif %}
 
 {%- elif datatype in ['image/svg+xml', 'image/png', 'image/jpeg', 'application/pdf'] %}
 


### PR DESCRIPTION
Closes #620.

If the cell output is empty (or contains only whitespace), the `raw` directive complains:

    WARNING: Content block expected for the "raw" directive; none found.

This has been introduced in #615.

@jdknight Please check if my proposed solution makes sense. If you know a better solution, please let me know!