### PR TITLE
Support .jp-RenderedHTMLCommon CSS class

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -656,6 +656,7 @@ div.nboutput.container div.output_area > div[class^='highlight']{
 }
 
 /* Some additional styling taken form the Jupyter notebook CSS */
+.jp-RenderedHTMLCommon table,
 div.rendered_html table {
   border: none;
   border-collapse: collapse;
@@ -664,10 +665,14 @@ div.rendered_html table {
   font-size: 12px;
   table-layout: fixed;
 }
+.jp-RenderedHTMLCommon thead,
 div.rendered_html thead {
   border-bottom: 1px solid black;
   vertical-align: bottom;
 }
+.jp-RenderedHTMLCommon tr,
+.jp-RenderedHTMLCommon th,
+.jp-RenderedHTMLCommon td,
 div.rendered_html tr,
 div.rendered_html th,
 div.rendered_html td {
@@ -679,12 +684,15 @@ div.rendered_html td {
   max-width: none;
   border: none;
 }
+.jp-RenderedHTMLCommon th,
 div.rendered_html th {
   font-weight: bold;
 }
+.jp-RenderedHTMLCommon tbody tr:nth-child(odd),
 div.rendered_html tbody tr:nth-child(odd) {
   background: #f5f5f5;
 }
+.jp-RenderedHTMLCommon tbody tr:hover,
 div.rendered_html tbody tr:hover {
   background: rgba(66, 165, 245, 0.2);
 }


### PR DESCRIPTION
If one e.g. uses `ipywidgets` to wrap a DataFrame, the output area has no `rendered_html` class, but `jp-RenderedHTMLCommon`

### Alternative

Using `:is(.rendered_html, .jp-RenderedHTMLCommon) table` would be a less verbose alternative that works in all current browser versions: https://caniuse.com/css-matches-pseudo