### PR TITLE
DOC: add example with rich content within Output widget

### DIFF
--- a/doc/code-cells.ipynb
+++ b/doc/code-cells.ipynb
@@ -557,6 +557,55 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Markdown Content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Markdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "md = Markdown(\"\"\"\n",
+    "# Markdown\n",
+    "\n",
+    "It *should* show up as **formatted** text\n",
+    "with things like [links] and images.\n",
+    "\n",
+    "[links]: https://jupyter.org/\n",
+    "\n",
+    "![Jupyter notebook icon](images/notebook_icon.png)\n",
+    "\n",
+    "## Markdown Extensions\n",
+    "\n",
+    "There might also be mathematical equations like\n",
+    "$a^2 + b^2 = c^2$\n",
+    "and even tables:\n",
+    "\n",
+    "A     | B     | A and B\n",
+    "------|-------|--------\n",
+    "False | False | False\n",
+    "True  | False | False\n",
+    "False | True  | False\n",
+    "True  | True  | True\n",
+    "\n",
+    "\"\"\")\n",
+    "md"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### YouTube Videos"
    ]
   },
@@ -671,7 +720,7 @@
    "outputs": [],
    "source": [
     "tabs = w.Tab()\n",
-    "for idx, obj in enumerate([df, fig, eq, i, slider]):\n",
+    "for idx, obj in enumerate([df, fig, eq, i, md, slider]):\n",
     "    out = w.Output()\n",
     "    with out:\n",
     "        display(obj)\n",

--- a/doc/code-cells.ipynb
+++ b/doc/code-cells.ipynb
@@ -665,6 +665,22 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tabs = w.Tab()\n",
+    "for idx, obj in enumerate([df, fig, eq, i, slider]):\n",
+    "    out = w.Output()\n",
+    "    with out:\n",
+    "        display(obj)\n",
+    "    tabs.children += out,\n",
+    "    tabs.set_title(idx, obj.__class__.__name__)\n",
+    "tabs"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/doc/code-cells.ipynb
+++ b/doc/code-cells.ipynb
@@ -616,7 +616,7 @@
    "outputs": [],
    "source": [
     "from IPython.display import YouTubeVideo\n",
-    "YouTubeVideo('WAikxUGbomY')"
+    "YouTubeVideo('9_OIs49m56E')"
    ]
   },
   {


### PR DESCRIPTION
This illustrates the problem described in #628.

Rendered: https://nbsphinx--633.org.readthedocs.build/en/633/code-cells.html#Interactive-Widgets-(HTML-only)

Math is broken as well, BTW.