### PR TITLE
Support dark mode

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -661,7 +661,6 @@ div.rendered_html table {
   border: none;
   border-collapse: collapse;
   border-spacing: 0;
-  color: black;
   font-size: 12px;
   table-layout: fixed;
 }
@@ -691,6 +690,10 @@ div.rendered_html th {
 .jp-RenderedHTMLCommon tbody tr:nth-child(odd),
 div.rendered_html tbody tr:nth-child(odd) {
   background: #f5f5f5;
+}
+body[data-theme="dark"] .jp-RenderedHTMLCommon tbody tr:nth-child(odd),
+body[data-theme="dark"] div.rendered_html tbody tr:nth-child(odd) {
+  background: rgba(255, 255, 255, .1);
 }
 .jp-RenderedHTMLCommon tbody tr:hover,
 div.rendered_html tbody tr:hover {


### PR DESCRIPTION
you use the furo theme, but don’t style data frames in a way that’s readable on a dark background:

this is how this page looks for me by default https://nbsphinx.readthedocs.io/en/furo-theme/code-cells.html:

![grafik](https://user-images.githubusercontent.com/291575/155308412-f607352f-d733-4df2-b1b4-a1e15a3e93a4.png)

after:

![grafik](https://user-images.githubusercontent.com/291575/155308296-ea2cfb4f-75fc-4dc0-af8b-be58b09915fe.png)

I don’t know if other themes’ dark modes