### PR TITLE
Add "alt" to supported image metadata keys

### DIFF
--- a/doc/code-cells.ipynb
+++ b/doc/code-cells.ipynb
@@ -448,6 +448,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The `width`, `height`, and `alt` attributes of the eventual HTML output can be set via cell metadata corresponding to the image format like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%config InlineBackend.figure_formats = ['png']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(fig, metadata={\"image/png\": {\"width\": \"150px\", \"height\": \"100px\",\n",
+    "                                     \"alt\": \"this is my alt text\"}})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Pandas Dataframes\n",
     "\n",
     "[Pandas dataframes](https://pandas.pydata.org/pandas-docs/stable/user_guide/dsintro.html#dataframe)\n",

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -181,7 +181,11 @@ RST_TEMPLATE = """
 {%- set height = output.metadata[datatype].height %}
 {%- if height %}
         :height: {{ height }}
-{% endif %}
+{%- endif %}
+{%- set alt = output.metadata[datatype].alt %}
+{%- if alt %}
+        :alt: {{ alt }}
+{%- endif %}
 {% endif %}
 {%- elif datatype in ['text/markdown'] %}
 


### PR DESCRIPTION
Hi @mgeier, this PR allows alt text to be specified in a code cell and end up in the resulting HTML.  Alt text is important for accessibility purposes as it is used by screen readers in place of the image itself.  It also adds a docs example for `width` and `height` (which I think are currently not present in the docs?) as well as `alt`.

Let me know if anything else is needed here; happy to push updates if so :)