### PR TITLE
Implement nblinkgallery directive

### DIFF
--- a/doc/a-normal-rst-file.rst
+++ b/doc/a-normal-rst-file.rst
@@ -302,7 +302,7 @@ Thumbnail Links Galleries
 -------------------------
 
 In some case it is desired to just create thumbnail links to existing notebooks,
-already inlcuded in a ``toctree``. This can be used e.g. to link to a subset
+already included in a ``toctree``. This can be used e.g. to link to a subset
 of notebooks from API documentation to highlight the use of some functionality.
 
 For this there is a dedicated ``nblinkgallery`` directive.

--- a/doc/a-normal-rst-file.rst
+++ b/doc/a-normal-rst-file.rst
@@ -299,18 +299,12 @@ The following example gallery was created using:
 
 
 Thumbnail Links Galleries (HTML only)
--------------------------
+-------------------------------------
 
 In some case it is desired to just create thumbnail links to existing notebooks,
 already included in a ``toctree``. This can be used e.g. to link to a subset
 of notebooks from API documentation to highlight the use of some functionality.
-
 For this there is a dedicated ``nblinkgallery`` directive.
-
-.. note::
-
-    The notes regarding LaTeX in :ref:`/subdir/gallery.ipynb`
-    and :ref:`/subdir/toctree.ipynb` also apply here!
 
 The following example gallery was created using:
 

--- a/doc/a-normal-rst-file.rst
+++ b/doc/a-normal-rst-file.rst
@@ -298,7 +298,7 @@ The following example gallery was created using:
     gallery/*-rst
 
 
-Thumbnail Links Galleries
+Thumbnail Links Galleries (HTML only)
 -------------------------
 
 In some case it is desired to just create thumbnail links to existing notebooks,

--- a/doc/a-normal-rst-file.rst
+++ b/doc/a-normal-rst-file.rst
@@ -296,3 +296,31 @@ The following example gallery was created using:
     :reversed:
 
     gallery/*-rst
+
+
+Thumbnail Links Galleries
+-------------------------
+
+In some case it is desired to just create thumbnail links to existing notebooks,
+already inlcuded in a ``toctree``. This can be used e.g. to link to a subset
+of notebooks from API documentation to highlight the use of some functionality.
+
+For this there is a dedicated ``nblinkgallery`` directive.
+
+.. note::
+
+    The notes regarding LaTeX in :ref:`/subdir/gallery.ipynb`
+    and :ref:`/subdir/toctree.ipynb` also apply here!
+
+The following example gallery was created using:
+
+.. code-block:: rest
+
+    .. nblinkgallery::
+        gallery/multiple-outputs.ipynb
+        gallery/no-thumbnail.ipynb
+
+.. nblinkgallery::
+    gallery/multiple-outputs.ipynb
+    gallery/no-thumbnail.ipynb
+

--- a/doc/a-normal-rst-file.rst
+++ b/doc/a-normal-rst-file.rst
@@ -311,10 +311,10 @@ The following example gallery was created using:
 .. code-block:: rest
 
     .. nblinkgallery::
-        gallery/multiple-outputs.ipynb
-        gallery/no-thumbnail.ipynb
+        gallery/multiple-outputs
+        gallery/no-thumbnail
 
 .. nblinkgallery::
-    gallery/multiple-outputs.ipynb
-    gallery/no-thumbnail.ipynb
+    gallery/multiple-outputs
+    gallery/no-thumbnail
 

--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -2101,7 +2101,53 @@ def env_updated(app, env):
         app.add_js_file(widgets_path, **app.config.nbsphinx_widgets_options)
 
 
+def has_wildcard(pattern):
+    return any(char in pattern for char in '*?[')
+
+
+def get_thumbnail_filename(app, thumbnail, doc):
+    matched = None
+    conf_py_thumbnail = None
+    conf_py_thumbnails = app.env.config.nbsphinx_thumbnails.items()
+
+    for pattern, candidate in conf_py_thumbnails:
+        if patmatch(doc, pattern):
+            if matched:
+                if has_wildcard(pattern):
+                    # warn if both patterns contain wildcards
+                    if has_wildcard(matched):
+                        logger.warning(
+                            'page %s matches two patterns in '
+                            'nbsphinx_thumbnails: %r and %r',
+                            doc, matched, pattern,
+                            type='nbsphinx', subtype='thumbnail')
+                    # else the already matched pattern is more
+                    # specific than the present one, because it
+                    # contains no wildcard
+                    continue
+            matched = pattern
+            conf_py_thumbnail = candidate
+
+    filename = thumbnail.get('filename', '')
+
+    if filename is _BROKEN_THUMBNAIL:
+        filename = os.path.join('_static', 'broken_example.png')
+    elif filename:
+        filename = os.path.join(app.builder.imagedir, filename)
+    elif conf_py_thumbnail:
+        # NB: Settings from conf.py can be overwritten in notebook
+        filename = conf_py_thumbnail
+    else:
+        filename = os.path.join('_static', 'no_image.png')
+
+    return filename
+
+
 def doctree_resolved(app, doctree, fromdocname):
+    base = sphinx.util.osutil.relative_uri(
+        app.builder.get_target_uri(fromdocname), ''
+    )
+
     # Replace GalleryToc with toctree + GalleryNode
     for node in doctree.traverse(GalleryToc):
         toctree_wrapper, = node
@@ -2116,62 +2162,56 @@ def doctree_resolved(app, doctree, fromdocname):
             if doc in toctree['includefiles']:
                 if title is None:
                     title = app.env.titles[doc].astext()
+
                 uri = app.builder.get_relative_uri(fromdocname, doc)
-                base = sphinx.util.osutil.relative_uri(
-                    app.builder.get_target_uri(fromdocname), '')
 
                 # NB: This is how Sphinx implements the "html_sidebars"
                 #     config value in StandaloneHTMLBuilder.add_sidebars()
 
-                def has_wildcard(pattern):
-                    return any(char in pattern for char in '*?[')
-
-                matched = None
-                conf_py_thumbnail = None
-                conf_py_thumbnails = app.env.config.nbsphinx_thumbnails.items()
-                for pattern, candidate in conf_py_thumbnails:
-                    if patmatch(doc, pattern):
-                        if matched:
-                            if has_wildcard(pattern):
-                                # warn if both patterns contain wildcards
-                                if has_wildcard(matched):
-                                    logger.warning(
-                                        'page %s matches two patterns in '
-                                        'nbsphinx_thumbnails: %r and %r',
-                                        doc, matched, pattern,
-                                        type='nbsphinx', subtype='thumbnail')
-                                # else the already matched pattern is more
-                                # specific than the present one, because it
-                                # contains no wildcard
-                                continue
-                        matched = pattern
-                        conf_py_thumbnail = candidate
-
                 thumbnail = app.env.nbsphinx_thumbnails.get(doc, {})
                 tooltip = thumbnail.get('tooltip', '')
-                filename = thumbnail.get('filename', '')
-                if filename is _BROKEN_THUMBNAIL:
-                    filename = os.path.join(
-                        base, '_static', 'broken_example.png')
-                elif filename:
-                    filename = os.path.join(
-                        base, app.builder.imagedir, filename)
-                elif conf_py_thumbnail:
-                    # NB: Settings from conf.py can be overwritten in notebook
-                    filename = os.path.join(base, conf_py_thumbnail)
-                else:
-                    filename = os.path.join(base, '_static', 'no_image.png')
+                filename = get_thumbnail_filename(
+                    app=app, thumbnail=thumbnail, doc=doc
+                )
+                filename = os.path.join(base, filename)
                 entries.append((title, uri, filename, tooltip))
             else:
                 logger.warning(
                     'External links are not supported in gallery: %s', doc,
-                    location=fromdocname, type='nbsphinx', subtype='gallery')
+                    location=fromdocname, type='nbsphinx', subtype='gallery'
+                )
+
         gallery = GalleryNode()
         gallery['entries'] = entries
         toctree['nbsphinx_gallery'] = True
         toctree_wrapper[:] = toctree,
         node.replace_self([toctree_wrapper, gallery])
         # NB: Further processing happens in patched_toctree_resolve()
+
+    path = Path(app.env.srcdir)
+
+    for node in doctree.traverse(GalleryLinks):
+        entries = []
+
+        for link in node["links"]:
+            path_link = link.relative_to(path)
+            doc = str(path_link.parent / path_link.stem)
+
+            thumbnail = app.env.nbsphinx_thumbnails.get(doc, {})
+
+            title = app.env.titles[doc].astext()
+            tooltip = thumbnail.get('tooltip', '')
+
+            filename = get_thumbnail_filename(
+                app=app, thumbnail=thumbnail, doc=doc
+            )
+
+            uri = app.builder.get_relative_uri(fromdocname, doc)
+            entries.append((title, uri, filename, tooltip))
+
+        gallery = GalleryNode()
+        gallery['entries'] = entries
+        node.replace_self([gallery])
 
 
 def depart_codearea_html(self, node):


### PR DESCRIPTION
This PR addresses issue #651 and includes the following changes:
- Implement new `NbLinkGallery` class and `nblinkgallery` directive
- Implement `GalleryLinks` node
- Adapt `doctree_resolve` to re-use the `GalleryNode` for `GalleryLinks` as well
- Add minimal docs example to `a-normal-rst-file.rst`

I consider this still as a draft. I'm happy to receive any comments for improvement, especial reduction of code duplication and improvement of documentation.