### PR TITLE
Fix missing backtick for literal mark-up in a markdown cell

### DIFF
--- a/doc/usage.ipynb
+++ b/doc/usage.ipynb
@@ -730,7 +730,7 @@
     "```\n",
     "Note:  \n",
     "\n",
-    "You migh have to change the line `docs/` to `docs/source` in case that you have this folder structure, which is the default when using `sphinx-quickstart. "
+    "You might have to change the line `docs/` to `docs/source` in case that you have this folder structure, which is the default when using `sphinx-quickstart`. "
    ]
   },
   {


### PR DESCRIPTION
relates https://github.com/spatialaudio/nbsphinx/pull/657#issuecomment-1206279663