### PR TITLE
CSS: Avoid line breaks in (empty) prompts

### DIFF
--- a/src/nbsphinx.py
+++ b/src/nbsphinx.py
@@ -595,10 +595,11 @@ div.nboutput.container div.prompt > div {
     }
 }
 
-/* disable scrollbars on prompts */
+/* disable scrollbars and line breaks on prompts */
 div.nbinput.container div.prompt pre,
 div.nboutput.container div.prompt pre {
     overflow: hidden;
+    white-space: pre;
 }
 
 /* input/output area */


### PR DESCRIPTION
See #671.