### PR TITLE
DOC: use "booktabs" table style for LaTeX

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -155,9 +155,10 @@ latex_elements = {
 }{
     \renewcommand{\ttdefault}{lmtt}  % typewriter font from lmodern
 }
-\usepackage{booktabs}  % for Pandas dataframes
 """,
 }
+
+latex_table_style = ['booktabs']
 
 latex_documents = [
     (master_doc, 'nbsphinx.tex', project, author, 'howto'),


### PR DESCRIPTION
This should actually be the default, but it isn't: https://github.com/sphinx-doc/sphinx/issues/10997