### PR TITLE
DOC: use docutils from SVN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,8 @@ jobs:
           command: |
             apt-get -y update
             apt-get install -y --no-install-recommends python3-pip librsvg2-bin binutils
+            # temporary, until docutils > 0.19.0 is released (see doc/requirements.txt):
+            apt-get install -y --no-install-recommends subversion
 
       - restore_cache:
           keys:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -10,3 +10,5 @@ sphinx-gallery<0.11  # https://github.com/spatialaudio/nbsphinx/issues/655
 jupytext
 sphinx-last-updated-by-git
 sphinx-codeautolink
+# docutils is an automatic dependency of Sphinx. This is only necessary until docutils > 0.19.0 is released:
+-e svn+https://svn.code.sf.net/p/docutils/code/trunk/docutils@9126#egg=docutils


### PR DESCRIPTION
This is a temporary work-around for https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/309

It can be removed after the next `docutils` release.