### PR TITLE
DOC: Remove explicit ipython dep from requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,4 @@
 ipykernel
-ipython!=8.7.0  # see https://github.com/spatialaudio/nbsphinx/issues/687
 numpy
 matplotlib
 pandas


### PR DESCRIPTION
IPython 8.8 has been released, see #687.