### PR TITLE
setup.py: remove zip_safe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,4 @@ setup(
         'Programming Language :: Python :: 3',
         'Topic :: Documentation :: Sphinx',
     ],
-    zip_safe=True,
 )


### PR DESCRIPTION
Since #705, the module is not zip-safe anymore.

But it turns out that the whole concept is deprecated, see https://setuptools.pypa.io/en/latest/deprecated/zip_safe.html

Removing it seems the right thing to do.