### PR TITLE
DOC: install "librsvg2-bin" on RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,6 +3,11 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3"
+  apt_packages:
+    # rsvg-convert for SVG -> PDF conversion
+    # using Sphinx extension sphinxcontrib.rsvgconverter, see
+    # https://github.com/missinglinkelectronics/sphinxcontrib-svg2pdfconverter
+    - librsvg2-bin
 python:
   install:
     - requirements: doc/requirements.txt


### PR DESCRIPTION
The package has been removed in https://github.com/readthedocs/readthedocs-docker-images/pull/166