### PR TITLE
Handle quotes in section titles

### DIFF
--- a/doc/markdown-cells.ipynb
+++ b/doc/markdown-cells.ipynb
@@ -539,6 +539,11 @@
     "\n",
     "You just have to remember to replace spaces with hyphens!\n",
     "\n",
+    "And if there are double quotes in the section title,\n",
+    "you'll have to replace them with `%22`,\n",
+    "like e.g. `#That's-a-%22Strange%22-Section` in this link:\n",
+    "[a section with \"strange\" characters](subdir/a-notebook-in-a-subdir.ipynb#That's-a-%22Strange%22-Section).\n",
+    "\n",
     "BTW, links to sections of the current notebook work, too, e.g.\n",
     "[beginning of this section](#Links-to-Other-Notebooks).\n",
     "\n",
@@ -547,6 +552,7 @@
     "```\n",
     "[beginning of this section](#Links-to-Other-Notebooks)\n",
     "```\n",
+    "\n",
     "It's also possible to create a\n",
     "[link to the beginning of the current page](#),\n",
     "by simply using a `#` character:\n",
@@ -650,7 +656,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/doc/subdir/a-notebook-in-a-subdir.ipynb
+++ b/doc/subdir/a-notebook-in-a-subdir.ipynb
@@ -58,13 +58,17 @@
     "## A Sub-Section\n",
     "\n",
     "This is just for testing inter-notebook links,\n",
-    "see [this section](../markdown-cells.ipynb#Links-to-Other-Notebooks)."
+    "see [this section](../markdown-cells.ipynb#Links-to-Other-Notebooks).\n",
+    "\n",
+    "## That's a \"Strange\" Section\n",
+    "\n",
+    "This is for testing links to a section title containing quotes."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -78,9 +82,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/src/nbsphinx/__init__.py
+++ b/src/nbsphinx/__init__.py
@@ -973,6 +973,7 @@ def markdown2rst(text):
 
     input_format = 'markdown'
     input_format += '-implicit_figures'
+    input_format += '-smart'  # Smart quotes etc. are handled by Sphinx
     v = nbconvert.utils.pandoc.get_pandoc_version()
     if nbconvert.utils.version.check_version(v, '1.13'):
         input_format += '-native_divs+raw_html'
@@ -1223,8 +1224,8 @@ class CreateNotebookSectionAnchors(docutils.transforms.Transform):
     def apply(self):
         all_ids = set()
         for section in self.document.traverse(docutils.nodes.section):
-            title = section.children[0].astext()
-            link_id = title.replace(' ', '-')
+            title = section[0].astext()
+            link_id = title.replace(' ', '-').replace('"', '%22')
             if link_id in all_ids:
                 # Avoid duplicated anchors on the same page
                 continue


### PR DESCRIPTION
Previously, Pandoc was creating smart quotes which ended up in the link anchors.