### PR TITLE
Fix support for links starting with `#`

### DIFF
--- a/src/nbsphinx/__init__.py
+++ b/src/nbsphinx/__init__.py
@@ -1229,11 +1229,13 @@ class RewriteLocalLinks(docutils.transforms.Transform):
             filename, fragment = _local_file_from_reference(
                 node, self.document)
             if not filename:
-                if fragment == '#':
-                    # This would work automagically in the HTML builder,
-                    # but it is needed for LaTeX.
+                if fragment:
+                    # This should not be needed if it weren't for
+                    # https://github.com/sphinx-doc/sphinx/issues/11336 and
+                    # https://github.com/sphinx-doc/sphinx/issues/11335
                     filename = os.path.basename(env.doc2path(env.docname))
-                    fragment = ''
+                    if fragment == '#':
+                        fragment = ''
                 else:
                     continue
 


### PR DESCRIPTION
There are two problems:

* https://github.com/sphinx-doc/sphinx/issues/11335
* https://github.com/sphinx-doc/sphinx/issues/11336

If those are fixed, this can be closed.

If not, this PR is a work-around that should also fix both problems.

Fixes a part of #530 (links to local files are still marked as "external").
Fixes #664.