### PR TITLE
hide copy-button in sphinx-immaterial theme

### DIFF
--- a/src/nbsphinx/_static/nbsphinx-code-cells.css_t
+++ b/src/nbsphinx/_static/nbsphinx-code-cells.css_t
@@ -62,12 +62,14 @@ div.nblast.container {
 }
 
 /* input prompt */
-div.nbinput.container div.prompt pre {
+div.nbinput.container div.prompt pre,
+div.nbinput.container div.prompt pre > code {
     color: #307FC1;
 }
 
 /* output prompt */
-div.nboutput.container div.prompt pre {
+div.nboutput.container div.prompt pre,
+div.nboutput.container div.prompt pre > code {
     color: #BF5B3D;
 }
 

--- a/src/nbsphinx/_static/nbsphinx-code-cells.css_t
+++ b/src/nbsphinx/_static/nbsphinx-code-cells.css_t
@@ -204,8 +204,9 @@ div.nboutput.container div.output_area > div[class^='highlight']{
     overflow-y: hidden;
 }
 
-/* hide copybtn icon on prompts (needed for 'sphinx_copybutton') */
-.prompt .copybtn {
+/* hide copybtn icon on prompts (needed for 'sphinx_copybutton' ext and `sphinx_immaterial` theme) */
+.prompt .copybtn,
+.prompt .md-clipboard.md-icon {
     display: none;
 }
 


### PR DESCRIPTION
resolves #732 

Branch reset to use the original approach in which the JS is not bypassed and the resulting copy-button is hidden in nbsphinx CSS.

Despite this approach being less performant with ClipboardJS usage, this approach seems to be the only feasible way to achieve the desired result; see https://github.com/spatialaudio/nbsphinx/pull/737#issuecomment-1535492952 for a detailed analysis.