### PR TITLE
DOC: remove sub-section about cell magics

### DIFF
--- a/doc/code-cells.ipynb
+++ b/doc/code-cells.ipynb
@@ -150,28 +150,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Cell Magics\n",
-    "\n",
-    "IPython can handle code in other languages by means of [cell magics](https://ipython.readthedocs.io/en/stable/interactive/magics.html#cell-magics):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "for i in 1 2 3\n",
-    "do\n",
-    "    echo $i\n",
-    "done"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Special Display Formats\n",
     "\n",
     "See [IPython example notebook](https://nbviewer.jupyter.org/github/ipython/ipython/blob/main/examples/IPython Kernel/Rich Output.ipynb)."


### PR DESCRIPTION
This is not necessary because the syntax highlighting of cell magics is also tested a bit later in the section about JavaScript.

Fixes #736.