### PR TITLE
Remove docutils work-around

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,6 @@ jobs:
           command: |
             apt-get -y update
             apt-get install -y --no-install-recommends python3-venv librsvg2-bin binutils pandoc
-            # temporary, until docutils > 0.19.0 is released (see doc/requirements.txt):
-            apt-get install -y --no-install-recommends subversion
 
       - restore_cache:
           keys:

--- a/doc/references.rst
+++ b/doc/references.rst
@@ -28,5 +28,4 @@ The list of references may look something like this:
     With ``docutils`` versions 0.18 and 0.19,
     the HTML output after the bibliography is broken,
     see https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/309.
-    This problem will be fixed in the next ``docutils`` version
-    (either 0.19.1 or 0.20).
+    This problem has been fixed in ``docutils`` version 0.20.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,5 +8,3 @@ ipywidgets
 jupytext
 sphinx-last-updated-by-git
 sphinx-codeautolink
-# docutils is an automatic dependency of Sphinx. This is only necessary until docutils > 0.19.0 is released:
--e svn+https://svn.code.sf.net/p/docutils/code/trunk/docutils@9126#egg=docutils


### PR DESCRIPTION
Docutils 0.20 has finally been released, hooray!

Sadly, Sphinx doesn't seem to support it yet: https://github.com/sphinx-doc/sphinx/issues/11414