### PR TITLE
DOC: use "master" branch of Sphinx

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -8,3 +8,4 @@ ipywidgets
 jupytext
 sphinx-last-updated-by-git
 sphinx-codeautolink
+git+https://github.com/sphinx-doc/sphinx.git@master


### PR DESCRIPTION
This is just to show a regression in the latest Sphinx `master` branch.

Rendered: https://nbsphinx--755.org.readthedocs.build/en/755/gallery/gallery-with-nested-documents.html

For comparison, an older Sphinx version (7.0.1): https://nbsphinx.readthedocs.io/en/0.9.2/gallery/gallery-with-nested-documents.html