### PR TITLE
Trying to work around upcoming changes in Sphinx 7.2.0

### DIFF
--- a/src/nbsphinx/__init__.py
+++ b/src/nbsphinx/__init__.py
@@ -1479,7 +1479,13 @@ class GetSizeFromImages(
                 node['width'], node['height'] = map(str, size)
 
 
-original_toctree_resolve = sphinx.environment.adapters.toctree.TocTree.resolve
+if hasattr(sphinx.environment.adapters.toctree, '_resolve_toctree'):
+    # Since Sphinx 7.2.0
+    original_toctree_resolve = \
+        sphinx.environment.adapters.toctree._resolve_toctree
+else:
+    original_toctree_resolve = \
+        sphinx.environment.adapters.toctree.TocTree.resolve
 
 
 def patched_toctree_resolve(self, docname, builder, toctree, *args, **kwargs):
@@ -2048,8 +2054,13 @@ def setup(app):
     rst.directives.register_directive('code', sphinx.directives.code.CodeBlock)
 
     # Monkey-patch Sphinx TocTree adapter
-    sphinx.environment.adapters.toctree.TocTree.resolve = \
-        patched_toctree_resolve
+    if hasattr(sphinx.environment.adapters.toctree, '_resolve_toctree'):
+        # Since Sphinx 7.2.0
+        sphinx.environment.adapters.toctree._resolve_toctree = \
+            patched_toctree_resolve
+    else:
+        sphinx.environment.adapters.toctree.TocTree.resolve = \
+            patched_toctree_resolve
 
     return {
         'version': __version__,


### PR DESCRIPTION
This doesn't work yet. The `nbsphinx_gallery` property doesn't seem to be propagated from ...

https://github.com/spatialaudio/nbsphinx/blob/55c48090f4dff967d1a9241fe60868c9ca097b64/src/nbsphinx/__init__.py#L1815

... to ...

https://github.com/spatialaudio/nbsphinx/blob/55c48090f4dff967d1a9241fe60868c9ca097b64/src/nbsphinx/__init__.py#L1494

Rendered: https://nbsphinx--756.org.readthedocs.build/en/756/gallery/gallery-with-nested-documents.html

See also #755.