### PR TITLE
Import CellExecutionError from nbconvert from the right place

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         'docutils',
         'jinja2',
-        'nbconvert!=5.4',
+        'nbconvert>=5.3,!=5.4',
         'traitlets>=5',
         'nbformat',
         'sphinx>=1.8',

--- a/src/nbsphinx/__init__.py
+++ b/src/nbsphinx/__init__.py
@@ -616,7 +616,7 @@ class NotebookParser(rst.Parser):
 
         try:
             rststring, resources = exporter.from_notebook_node(nb, resources)
-        except nbconvert.preprocessors.execute.CellExecutionError as e:
+        except nbconvert.preprocessors.CellExecutionError as e:
             lines = str(e).split('\n')
             lines[0] = 'CellExecutionError in {}:'.format(
                 env.doc2path(env.docname, base=None))


### PR DESCRIPTION
newer versions of nbconvert now define CellExecutionError only from nbconvert.preprocessors

I guess also a test is missing which made this part of code never trigger the crash ( I get it because in my sphinx build something is triggering it)