### PR TITLE
include all items from  `doc/` in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,4 @@
 include LICENSE
 include *.rst
-include doc/requirements.txt
-include doc/conf.py
-include doc/*.rst
-include doc/*.ipynb
-include doc/subdir/*.ipynb
-include doc/images/*
-include doc/references.bib
-include doc/ipython_kernel_config.py
+include doc/requirements.txt doc/references.bib
+recursive-include doc *.ipynb matplotlibrc *.md *.rst *.py *.txt *.svg *.png


### PR DESCRIPTION
https://files.pythonhosted.org/packages/51/31/85cb6129d22c75722d1e1a8db0cdaf36ab7e1e7a59189bfa275445c8ab2d/nbsphinx-0.9.3.tar.gz is missing quite a few number of files
