### PR TITLE
CI: stop ignoring PendingDeprecationWarning about Node.traverse()

### DIFF
--- a/.github/workflows/html-macos.yml
+++ b/.github/workflows/html-macos.yml
@@ -39,7 +39,6 @@ jobs:
     - name: Build HTML
       env:
         # There is a weird warning from jupyter_core (https://github.com/jupyter/jupyter_core/issues/398)
-        # The other warning will be fixed with https://github.com/spatialaudio/nbsphinx/pull/758
-        PYTHONWARNINGS: error,default::DeprecationWarning,default:nodes.Node.traverse() is obsoleted by Node.findall():PendingDeprecationWarning
+        PYTHONWARNINGS: error,default::DeprecationWarning
       run: |
         $SPHINX doc/ _build/html/

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -40,8 +40,7 @@ jobs:
     - name: Check links
       env:
         # There is a weird warning from jupyter_core (https://github.com/jupyter/jupyter_core/issues/398)
-        # The other warning will be fixed with https://github.com/spatialaudio/nbsphinx/pull/758
-        PYTHONWARNINGS: error,default::DeprecationWarning,default:nodes.Node.traverse() is obsoleted by Node.findall():PendingDeprecationWarning
+        PYTHONWARNINGS: error,default::DeprecationWarning
       run: |
         $SPHINX -d _doctrees/ doc/ _build/linkcheck/ -b linkcheck -q
     - name: Upload results

--- a/.github/workflows/version-matrix.yml
+++ b/.github/workflows/version-matrix.yml
@@ -80,7 +80,6 @@ jobs:
     - name: Run Sphinx
       env:
         # There is a weird warning from jupyter_core (https://github.com/jupyter/jupyter_core/issues/398)
-        # The other warning will be fixed with https://github.com/spatialaudio/nbsphinx/pull/758
-        PYTHONWARNINGS: error,default::DeprecationWarning,default:nodes.Node.traverse() is obsoleted by Node.findall():PendingDeprecationWarning
+        PYTHONWARNINGS: error,default::DeprecationWarning
       run: |
         $SPHINX doc _build -b html


### PR DESCRIPTION
This is a follow-up to #758.