### PR TITLE
CI: ignore deprecated import_object

### DIFF
--- a/.github/workflows/html-macos.yml
+++ b/.github/workflows/html-macos.yml
@@ -39,6 +39,8 @@ jobs:
     - name: Build HTML
       env:
         # There is a weird warning from jupyter_core (https://github.com/jupyter/jupyter_core/issues/398)
-        PYTHONWARNINGS: error,default::DeprecationWarning
+        # RemovedInSphinx10Warning: 'sphinx.util.import_object' is deprecated
+        # https://github.com/sphinx-doc/sphinx/issues/13083
+        PYTHONWARNINGS: error,default::DeprecationWarning,default:'sphinx.util.import_object'
       run: |
         $SPHINX doc/ _build/html/

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -40,7 +40,9 @@ jobs:
     - name: Check links
       env:
         # There is a weird warning from jupyter_core (https://github.com/jupyter/jupyter_core/issues/398)
-        PYTHONWARNINGS: error,default::DeprecationWarning
+        # RemovedInSphinx10Warning: 'sphinx.util.import_object' is deprecated
+        # https://github.com/sphinx-doc/sphinx/issues/13083
+        PYTHONWARNINGS: error,default::DeprecationWarning,default:'sphinx.util.import_object'
       run: |
         $SPHINX -d _doctrees/ doc/ _build/linkcheck/ -b linkcheck -q
     - name: Upload results

--- a/.github/workflows/version-matrix.yml
+++ b/.github/workflows/version-matrix.yml
@@ -79,18 +79,24 @@ jobs:
     - name: Run Sphinx (HTML)
       env:
         # There is a weird warning from jupyter_core (https://github.com/jupyter/jupyter_core/issues/398)
-        PYTHONWARNINGS: error,default::DeprecationWarning
+        # RemovedInSphinx10Warning: 'sphinx.util.import_object' is deprecated
+        # https://github.com/sphinx-doc/sphinx/issues/13083
+        PYTHONWARNINGS: error,default::DeprecationWarning,default:'sphinx.util.import_object'
       run: |
         $SPHINX doc _build -b html
     - name: Run Sphinx (LaTeX, but without running LaTeX)
       env:
         # There is a weird warning from jupyter_core (https://github.com/jupyter/jupyter_core/issues/398)
-        PYTHONWARNINGS: error,default::DeprecationWarning
+        # RemovedInSphinx10Warning: 'sphinx.util.import_object' is deprecated
+        # https://github.com/sphinx-doc/sphinx/issues/13083
+        PYTHONWARNINGS: error,default::DeprecationWarning,default:'sphinx.util.import_object'
       run: |
         $SPHINX doc _build -b latex
     - name: Run Sphinx (epub)
       env:
         # There is a weird warning from jupyter_core (https://github.com/jupyter/jupyter_core/issues/398)
-        PYTHONWARNINGS: error,default::DeprecationWarning
+        # RemovedInSphinx10Warning: 'sphinx.util.import_object' is deprecated
+        # https://github.com/sphinx-doc/sphinx/issues/13083
+        PYTHONWARNINGS: error,default::DeprecationWarning,default:'sphinx.util.import_object'
       run: |
         $SPHINX doc _build -b epub

--- a/doc/code-cells.ipynb
+++ b/doc/code-cells.ipynb
@@ -150,9 +150,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Special Display Formats\n",
-    "\n",
-    "See [IPython example notebook](https://nbviewer.org/github/ipython/ipython/blob/main/examples/IPython%20Kernel/Rich%20Output.ipynb)."
+    "## Special Display Formats"
    ]
   },
   {


### PR DESCRIPTION
The deprecation will hopefully be reverted (see https://github.com/sphinx-doc/sphinx/issues/13083), and then we can un-ignore it again.

This also removes a link which was broken by https://github.com/ipython/ipython/pull/14572.