### PR TITLE
Add sphinx.util.console import for 8.2.0 compatibility

### DIFF
--- a/src/nbsphinx/__init__.py
+++ b/src/nbsphinx/__init__.py
@@ -28,6 +28,7 @@ import sphinx.directives.other
 import sphinx.environment
 import sphinx.errors
 import sphinx.transforms.post_transforms.images
+import sphinx.util.console
 from sphinx.util.matching import patmatch
 try:
     from sphinx.util.display import status_iterator


### PR DESCRIPTION
Fixes #825

A more minimal version of https://github.com/spatialaudio/nbsphinx/pull/826

See also https://github.com/spatialaudio/nbsphinx/issues/825#issuecomment-2670307450