### PR TITLE
Disable Sphinx 8.2

### DIFF
--- a/.github/workflows/version-matrix.yml
+++ b/.github/workflows/version-matrix.yml
@@ -36,12 +36,11 @@ jobs:
 
           # a few Python versions using latest Sphinx release
           - env:
-              PYTHON_VERSION: "3.8"
-          - env:
               PYTHON_VERSION: "3.10"
           - env:
-              PYTHON_VERSION: "3.13-dev"
-              PYTHONWARNINGS: default
+              PYTHON_VERSION: "3.11"
+          - env:
+              PYTHON_VERSION: "3.13"
 
     env: ${{ matrix.env || fromJSON('{}') }}
     steps:

--- a/.github/workflows/version-matrix.yml
+++ b/.github/workflows/version-matrix.yml
@@ -19,10 +19,14 @@ jobs:
           - env: {}
 
           # a few older Sphinx releases using default Python version
+          # sphinx 5.0 and 5.3 requires the imghdr module removed
+          # in python 3.13 so test with 3.12
           - env:
               SPHINX_PACKAGE: "sphinx==5.0.0 sphinxcontrib-bibtex==2.5.0"
+              PYTHON_VERSION: "3.12"
           - env:
               SPHINX_PACKAGE: "sphinx==5.3.0 sphinxcontrib-bibtex==2.5.0"
+              PYTHON_VERSION: "3.12"
           - env:
               SPHINX_PACKAGE: "sphinx==6.2.1 sphinxcontrib-bibtex==2.5.0"
           - env:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,4 +17,6 @@ python:
     - method: pip
       path: .
     - requirements: doc/fallback_theme.txt
+sphinx:
+  configuration: doc/conf.py
 formats: all

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -117,6 +117,9 @@ linkcheck_ignore = [
     'https://github.com/spatialaudio/nbsphinx/compare/',
     # 418 Client Error: Unknown for url: https://ieeexplore.ieee.org/document/5582063/
     'https://doi.org/10.1109/MCSE.2010.119',
+    # Intermittent network errors:
+    # Failed to establish a new connection: [Errno 101] Network is unreachable
+    'https://repology.org/',
 ]
 
 nitpicky = True

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
         'nbconvert>=5.3,!=5.4',
         'traitlets>=5',
         'nbformat',
-        'sphinx>=1.8',
+        # https://github.com/spatialaudio/nbsphinx/issues/825
+        'sphinx >= 1.8, < 8.2',
     ],
     author='Matthias Geier',
     author_email='Matthias.Geier@gmail.com',


### PR DESCRIPTION
In general, I think pinning upper version bounds is not the right approach, but given the slew of incompatibilities introduced by Sphinx (in part involving 3rd party dependencies), I think it is best for my sanity and for most casual `nbsphinx` users to restrict Sphinx upgrades for now.

I hope it will become easier to support Sphinx upgrades at a later point.

This PR includes #823 in its entirety and parts of #826.