### PR TITLE
Force long output text to scroll

### DIFF
--- a/src/nbsphinx/_static/nbsphinx-code-cells.css_t
+++ b/src/nbsphinx/_static/nbsphinx-code-cells.css_t
@@ -128,6 +128,11 @@ div.nboutput.container div.output_area {
         width: 100%;
     }
 }
+/* scroll long text outputs vertically */
+div.nboutput.container div.output_area:has(pre) {
+    max-height: 600px;
+}
+
 
 /* input area */
 div.nbinput.container div.input_area {


### PR DESCRIPTION
Currently, long cell output does not scroll. This has been adressed in issues #417 and #372.

These cells are already correctly configured to scroll upon overflow from various parent classes.
The reason these outputs don't scroll vertically is simply because there is no limit on how much vertical space they are allowed to take, so they never overflow.

This PR simply implements a maximum height for all `nboutput container` classes, but only for those that contain text.
Checking if they contain text is done by checking if they have a child with `pre`. I'm not very accustomed to CSS, so I don't know if this is a good way to check.