### PR TITLE
Remove deprecated license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ setup(
         'Framework :: Jupyter',
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
This caused a CI failure (and is redundant anyway).