### PR TITLE
DOC: add separate examples for inline, block and cell output math

### DIFF
--- a/doc/gallery/cinque-rst.ipynb
+++ b/doc/gallery/cinque-rst.ipynb
@@ -13,9 +13,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Dummy Notebook 1 for Gallery\n",
+    "# Dummy Notebook 5 for Gallery\n",
     "\n",
-    "This is a dummy file just to fill\n",
+    "This is another dummy file to fill\n",
     "[the gallery in the reST file](../a-normal-rst-file.rst#thumbnail-galleries).\n",
     "\n",
     "The thumbnail image is assigned in [conf.py](../conf.py)."
@@ -26,12 +26,8 @@
    "metadata": {},
    "source": [
     "This page has a secondary use, though,\n",
-    "which is testing whether a single block math equation works\n",
-    "(if there is no other math on the same page):\n",
-    "\n",
-    "\\begin{equation}\n",
-    "\\int\\limits_{-\\infty}^\\infty f(x) \\delta(x - x_0) dx = f(x_0).\n",
-    "\\end{equation}"
+    "which is testing whether a single inline math equation works\n",
+    "(if there is no other math on the same page): $\\text{e}^{i\\pi} = -1$."
    ]
   }
  ],

--- a/doc/gallery/due-rst.pct.py
+++ b/doc/gallery/due-rst.pct.py
@@ -19,3 +19,13 @@ from pathlib import Path
 filename = 'due-rst.pct.py'
 
 print(Path(filename).read_text())
+
+# %% [markdown]
+# This page has a secondary use,
+# which is testing whether a single math output cell works
+# (if there is no other math on the same page):
+
+# %%
+from IPython.display import Math
+eq = Math(r'\int\limits_{-\infty}^\infty f(x) \delta(x - x_0) dx = f(x_0)')
+eq


### PR DESCRIPTION
This adds examples that show the problem that #822 doesn't quite solve.

They will also serve as regression tests once it does work.

A possible solution is to use [`app.set_html_assets_policy('always')`](https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.set_html_assets_policy), as suggested in https://github.com/spatialaudio/nbsphinx/pull/822#issuecomment-2664315587.