### PR TITLE
add gif support

### DIFF
--- a/src/nbsphinx/__init__.py
+++ b/src/nbsphinx/__init__.py
@@ -79,6 +79,7 @@ DISPLAY_DATA_PRIORITY_HTML = (
     'text/latex',
     'image/png',
     'image/jpeg',
+    'image/gif',
     'text/plain',
 )
 # See nbconvert/exporters/latex.py:
@@ -96,6 +97,7 @@ THUMBNAIL_MIME_TYPES = {
     'image/svg+xml': '.svg',
     'image/png': '.png',
     'image/jpeg': '.jpg',
+    'image/gif': '.gif',
 }
 
 # The default rst template name is changing in nbconvert 6, so we substitute
@@ -180,7 +182,7 @@ RST_TEMPLATE = """
 {{ output.data[datatype] | indent | indent }}
 {%- endif %}
 
-{%- elif datatype in ['image/svg+xml', 'image/png', 'image/jpeg', 'application/pdf'] %}
+{%- elif datatype in ['image/svg+xml', 'image/png', 'image/jpeg', 'image/gif', 'application/pdf'] %}
 
     .. image:: {{ output.metadata.filenames[datatype] | posix_path }}
 {%- if datatype in output.metadata %}


### PR DESCRIPTION
# Add GIF Image Support to nbsphinx

## Summary

This pull request adds support for rendering animated GIF images in Jupyter notebooks when using nbsphinx (see also #864 ). The implementation follows the same approach used in similar projects like [WhipperSnapPy](https://github.com/Deep-MI/WhipperSnapPy/pull/59) and the [nbconvert PR for GIF support](https://github.com/jupyter/nbconvert/pull/2271).
Note that we do not add a monkey patch for nbconvert here, so first the PR upstream needs to be merged before this will work. 

## Changes Made

### 1. Added `image/gif` to Display Data Priority (HTML)
- **File**: `src/nbsphinx/__init__.py`
- **Change**: Added `'image/gif'` to the `DISPLAY_DATA_PRIORITY_HTML` tuple
- **Purpose**: Ensures GIF images are considered as valid output types when rendering HTML output, with appropriate priority relative to other image formats

### 2. Added GIF File Extension Mapping
- **File**: `src/nbsphinx/__init__.py`
- **Change**: Added `'image/gif': '.gif'` to the `THUMBNAIL_MIME_TYPES` dictionary
- **Purpose**: Allows the system to correctly identify and use `.gif` file extensions when saving GIF images as thumbnails or standalone files

### 3. Updated RST Template for Image Directive
- **File**: `src/nbsphinx/__init__.py` (RST_TEMPLATE)
- **Change**: Added `'image/gif'` to the image directive handling condition in the Jinja2 template
- **Purpose**: Enables proper rendering of GIF images using reStructuredText's `image` directive
